### PR TITLE
Fix local JWT fallback behavior

### DIFF
--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/sessions/Sessions.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/sessions/Sessions.kt
@@ -519,14 +519,13 @@ internal class SessionsImpl(
         authorizationCheck: AuthorizationCheck?,
     ): StytchResult<MemberSession?> =
         withContext(Dispatchers.IO) {
-            try {
-                authenticateJwtLocal(jwt = jwt, maxTokenAgeSeconds = maxTokenAgeSeconds, authorizationCheck = authorizationCheck)
-            } catch (e: JWTException) {
-                when (val result = authenticate(AuthenticateRequest(sessionJwt = jwt, authorizationCheck = authorizationCheck))) {
-                    is StytchResult.Success -> StytchResult.Success(result.value.memberSession)
-                    else -> StytchResult.Success(null)
-                }
+          when (val localResult = authenticateJwtLocal(jwt = jwt, maxTokenAgeSeconds = maxTokenAgeSeconds, authorizationCheck = authorizationCheck)) {
+            is StytchResult.Success -> StytchResult.Success(localResult.value.memberSession)
+            else -> when (val netResult = authenticate(AuthenticateRequest(sessionJwt = jwt, authorizationCheck = authorizationCheck))) {
+              is StytchResult.Success -> StytchResult.Success(netResult.value.memberSession)
+              else -> StytchResult.Success(null)
             }
+          }
         }
 
     override fun authenticateJwt(

--- a/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
@@ -1,3 +1,3 @@
 package com.stytch.java.common
 
-internal const val VERSION = "2.0.0"
+internal const val VERSION = "2.0.1"

--- a/stytch/src/main/kotlin/com/stytch/java/consumer/api/sessions/Sessions.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/consumer/api/sessions/Sessions.kt
@@ -385,17 +385,13 @@ internal class SessionsImpl(
         maxTokenAgeSeconds: Int?,
     ): StytchResult<JWTResponse?> =
         withContext(Dispatchers.IO) {
-            try {
-                when (val result = authenticateJwtLocal(jwt = jwt, maxTokenAgeSeconds = maxTokenAgeSeconds)) {
-                    is StytchResult.Success -> StytchResult.Success(JWTSessionResponse(result.value))
-                    else -> StytchResult.Success(JWTNullResponse)
-                }
-            } catch (e: JWTException) {
-                when (val result = authenticate(AuthenticateRequest(sessionJwt = jwt))) {
-                    is StytchResult.Success -> StytchResult.Success(JWTAuthResponse(result.value))
-                    else -> StytchResult.Success(JWTNullResponse)
-                }
+          when (val localResult = authenticateJwtLocal(jwt = jwt, maxTokenAgeSeconds = maxTokenAgeSeconds)) {
+            is StytchResult.Success -> StytchResult.Success(JWTSessionResponse(localResult.value)
+            else -> when (val netResult = authenticate(AuthenticateRequest(sessionJwt = jwt))) {
+              is StytchResult.Success -> StytchResult.Success(JWTAuthResponse(netResult.value))
+              else -> StytchResult.Success(null)
             }
+          }
         }
 
     override fun authenticateJwt(

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,1 +1,1 @@
-version = "2.0.0"
+version = "2.0.1"


### PR DESCRIPTION
I feel _somewhat_ confident that this is the approach we want.

One thing to note: it's possible that we're now retrying some requests that we *know* will also error in the API, but my logic was "if we can't do it locally, at least give the API a chance to interpret the JWT"