### PR TITLE
Update docs and support set_email_verified

### DIFF
--- a/stytch/src/main/kotlin/com/stytch/java/b2b/StytchB2BClient.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/StytchB2BClient.kt
@@ -37,6 +37,7 @@ import com.stytch.java.http.HttpClient
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import org.jose4j.jwk.HttpsJwks
+
 public object StytchB2BClient {
     private lateinit var httpClient: HttpClient
     private lateinit var httpsJwks: HttpsJwks

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/rbac/RBAC.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/rbac/RBAC.kt
@@ -27,13 +27,13 @@ public interface RBAC {
      * Get the active RBAC Policy for your current Stytch Project. An RBAC Policy is the canonical document that stores all
      * defined Resources and Roles within your RBAC permissioning model.
      *
-     * When using the backend SDKs, the RBAC Policy will automatically be loaded and refreshed in the background to allow for
-     * local evaluations, eliminating the need for an extra request to Stytch.
+     * When using the backend SDKs, the RBAC Policy will be cached to allow for local evaluations, eliminating the need for an
+     * extra request to Stytch. The policy will be refreshed if an authorization check is requested and the RBAC policy was
+     * last updated more than 5 minutes ago.
      *
-     * Resources and Roles can be created and managed within the [Dashboard](/dashboard). Additionally,
+     * Resources and Roles can be created and managed within the [Dashboard](/dashboard/rbac). Additionally,
      * [Role assignment](https://stytch.com/docs/b2b/guides/rbac/role-assignment) can be programmatically managed through
      * certain Stytch API endpoints.
-     *
      *
      * Check out the [RBAC overview](https://stytch.com/docs/b2b/guides/rbac/overview) to learn more about Stytch's RBAC
      * permissioning model.
@@ -44,13 +44,13 @@ public interface RBAC {
      * Get the active RBAC Policy for your current Stytch Project. An RBAC Policy is the canonical document that stores all
      * defined Resources and Roles within your RBAC permissioning model.
      *
-     * When using the backend SDKs, the RBAC Policy will automatically be loaded and refreshed in the background to allow for
-     * local evaluations, eliminating the need for an extra request to Stytch.
+     * When using the backend SDKs, the RBAC Policy will be cached to allow for local evaluations, eliminating the need for an
+     * extra request to Stytch. The policy will be refreshed if an authorization check is requested and the RBAC policy was
+     * last updated more than 5 minutes ago.
      *
-     * Resources and Roles can be created and managed within the [Dashboard](/dashboard). Additionally,
+     * Resources and Roles can be created and managed within the [Dashboard](/dashboard/rbac). Additionally,
      * [Role assignment](https://stytch.com/docs/b2b/guides/rbac/role-assignment) can be programmatically managed through
      * certain Stytch API endpoints.
-     *
      *
      * Check out the [RBAC overview](https://stytch.com/docs/b2b/guides/rbac/overview) to learn more about Stytch's RBAC
      * permissioning model.
@@ -64,13 +64,13 @@ public interface RBAC {
      * Get the active RBAC Policy for your current Stytch Project. An RBAC Policy is the canonical document that stores all
      * defined Resources and Roles within your RBAC permissioning model.
      *
-     * When using the backend SDKs, the RBAC Policy will automatically be loaded and refreshed in the background to allow for
-     * local evaluations, eliminating the need for an extra request to Stytch.
+     * When using the backend SDKs, the RBAC Policy will be cached to allow for local evaluations, eliminating the need for an
+     * extra request to Stytch. The policy will be refreshed if an authorization check is requested and the RBAC policy was
+     * last updated more than 5 minutes ago.
      *
-     * Resources and Roles can be created and managed within the [Dashboard](/dashboard). Additionally,
+     * Resources and Roles can be created and managed within the [Dashboard](/dashboard/rbac). Additionally,
      * [Role assignment](https://stytch.com/docs/b2b/guides/rbac/role-assignment) can be programmatically managed through
      * certain Stytch API endpoints.
-     *
      *
      * Check out the [RBAC overview](https://stytch.com/docs/b2b/guides/rbac/overview) to learn more about Stytch's RBAC
      * permissioning model.

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/discoveryorganizations/DiscoveryOrganizations.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/discoveryorganizations/DiscoveryOrganizations.kt
@@ -182,18 +182,18 @@ public data class CreateRequest
         @Json(name = "rbac_email_implicit_role_assignments")
         val rbacEmailImplicitRoleAssignments: List<EmailImplicitRoleAssignment>? = null,
         /**
-         * The setting that controls which mfa methods can be used by Members of an Organization. The accepted values are:
+         * The setting that controls which MFA methods can be used by Members of an Organization. The accepted values are:
          *
          *   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
          *
-         *   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication. This setting does
+         *   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication. This setting does
          * not apply to Members with `is_breakglass` set to `true`.
          *
          */
         @Json(name = "mfa_methods")
         val mfaMethods: String? = null,
         /**
-         * An array of allowed mfa authentication methods. This list is enforced when `mfa_methods` is set to `RESTRICTED`.
+         * An array of allowed MFA authentication methods. This list is enforced when `mfa_methods` is set to `RESTRICTED`.
          *   The list's accepted values are: `sms_otp` and `totp`.
          *
          */

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/organizations/Organizations.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/organizations/Organizations.kt
@@ -433,18 +433,18 @@ public data class Organization
         @Json(name = "rbac_email_implicit_role_assignments")
         val rbacEmailImplicitRoleAssignments: List<EmailImplicitRoleAssignment>,
         /**
-         * The setting that controls which mfa methods can be used by Members of an Organization. The accepted values are:
+         * The setting that controls which MFA methods can be used by Members of an Organization. The accepted values are:
          *
          *   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
          *
-         *   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication. This setting does
+         *   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication. This setting does
          * not apply to Members with `is_breakglass` set to `true`.
          *
          */
         @Json(name = "mfa_methods")
         val mfaMethods: String,
         /**
-         * An array of allowed mfa authentication methods. This list is enforced when `mfa_methods` is set to `RESTRICTED`.
+         * An array of allowed MFA authentication methods. This list is enforced when `mfa_methods` is set to `RESTRICTED`.
          *   The list's accepted values are: `sms_otp` and `totp`.
          *
          */
@@ -664,18 +664,18 @@ public data class CreateRequest
         @Json(name = "rbac_email_implicit_role_assignments")
         val rbacEmailImplicitRoleAssignments: List<EmailImplicitRoleAssignment>? = null,
         /**
-         * The setting that controls which mfa methods can be used by Members of an Organization. The accepted values are:
+         * The setting that controls which MFA methods can be used by Members of an Organization. The accepted values are:
          *
          *   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
          *
-         *   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication. This setting does
+         *   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication. This setting does
          * not apply to Members with `is_breakglass` set to `true`.
          *
          */
         @Json(name = "mfa_methods")
         val mfaMethods: String? = null,
         /**
-         * An array of allowed mfa authentication methods. This list is enforced when `mfa_methods` is set to `RESTRICTED`.
+         * An array of allowed MFA authentication methods. This list is enforced when `mfa_methods` is set to `RESTRICTED`.
          *   The list's accepted values are: `sms_otp` and `totp`.
          *
          */
@@ -1035,21 +1035,21 @@ public data class UpdateRequest
         @Json(name = "rbac_email_implicit_role_assignments")
         val rbacEmailImplicitRoleAssignments: List<String>? = null,
         /**
-         * The setting that controls which mfa methods can be used by Members of an Organization. The accepted values are:
+         * The setting that controls which MFA methods can be used by Members of an Organization. The accepted values are:
          *
          *   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
          *
-         *   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication. This setting does
+         *   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication. This setting does
          * not apply to Members with `is_breakglass` set to `true`.
          *
          *
          * If this field is provided and a session header is passed into the request, the Member Session must have permission to
-         * perform the `update.settings.allowed-auth-methods` action on the `stytch.organization` Resource.
+         * perform the `update.settings.allowed-mfa-methods` action on the `stytch.organization` Resource.
          */
         @Json(name = "mfa_methods")
         val mfaMethods: String? = null,
         /**
-         * An array of allowed mfa authentication methods. This list is enforced when `mfa_methods` is set to `RESTRICTED`.
+         * An array of allowed MFA authentication methods. This list is enforced when `mfa_methods` is set to `RESTRICTED`.
          *   The list's accepted values are: `sms_otp` and `totp`.
          *
          *

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/organizationsmembers/OrganizationsMembers.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/organizationsmembers/OrganizationsMembers.kt
@@ -726,7 +726,7 @@ public data class UpdateRequest
          * `auth_methods` and `allowed_auth_methods` fields for more details.
          *
          * If this field is provided and a session header is passed into the request, the Member Session must have permission to
-         * perform the `update.info.is-breakglass` action on the `stytch.member` Resource.
+         * perform the `update.settings.is-breakglass` action on the `stytch.member` Resource.
          */
         @Json(name = "is_breakglass")
         val isBreakglass: Boolean? = null,

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/rbac/RBAC.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/rbac/RBAC.kt
@@ -29,10 +29,73 @@ public data class Policy
 public data class PolicyResource
     @JvmOverloads
     constructor(
+        /**
+         * A unique identifier of the RBAC Resource, provided by the developer and intended to be human-readable.
+         *
+         *   A `resource_id` is not allowed to start with `stytch`, which is a special prefix used for Stytch default Resources
+         * with reserved  `resource_id`s. These include:
+         *
+         *   * `stytch.organization`
+         *   * `stytch.member`
+         *   * `stytch.sso`
+         *   * `stytch.self`
+         *
+         *   Check out the [guide on Stytch default Resources](https://stytch.com/docs/b2b/guides/rbac/stytch-defaults) for a more
+         * detailed explanation.
+         *
+         *
+         */
         @Json(name = "resource_id")
         val resourceId: String,
+        /**
+         * The description of the RBAC Resource.
+         */
         @Json(name = "description")
         val description: String,
+        /**
+         * A list of all possible actions for a provided Resource.
+         *
+         *   Reserved `actions` that are predefined by Stytch include:
+         *
+         *   * `*`
+         *   * For the `stytch.organization` Resource:
+         *     * `update.info.name`
+         *     * `update.info.slug`
+         *     * `update.info.untrusted_metadata`
+         *     * `update.info.email_jit_provisioning`
+         *     * `update.info.logo_url`
+         *     * `update.info.email_invites`
+         *     * `update.info.allowed_domains`
+         *     * `update.info.default_sso_connection`
+         *     * `update.info.sso_jit_provisioning`
+         *     * `update.info.mfa_policy`
+         *     * `update.info.implicit_roles`
+         *     * `delete`
+         *   * For the `stytch.member` Resource:
+         *     * `create`
+         *     * `update.info.name`
+         *     * `update.info.untrusted_metadata`
+         *     * `update.info.mfa-phone`
+         *     * `update.info.delete.mfa-phone`
+         *     * `update.settings.is-breakglass`
+         *     * `update.settings.mfa_enrolled`
+         *     * `update.settings.roles`
+         *     * `search`
+         *     * `delete`
+         *   * For the `stytch.sso` Resource:
+         *     * `create`
+         *     * `update`
+         *     * `delete`
+         *   * For the `stytch.self` Resource:
+         *     * `update.info.name`
+         *     * `update.info.untrusted_metadata`
+         *     * `update.info.mfa-phone`
+         *     * `update.info.delete.mfa-phone`
+         *     * `update.info.delete.password`
+         *     * `update.settings.mfa_enrolled`
+         *     * `delete`
+         *
+         */
         @Json(name = "actions")
         val actions: List<String>,
     )
@@ -41,10 +104,29 @@ public data class PolicyResource
 public data class PolicyRole
     @JvmOverloads
     constructor(
+        /**
+         * The unique identifier of the RBAC Role, provided by the developer and intended to be human-readable.
+         *
+         *   Reserved `role_id`s that are predefined by Stytch include:
+         *
+         *   * `stytch_member`
+         *   * `stytch_admin`
+         *
+         *   Check out the [guide on Stytch default Roles](https://stytch.com/docs/b2b/guides/rbac/stytch-defaults) for a more
+         * detailed explanation.
+         *
+         *
+         */
         @Json(name = "role_id")
         val roleId: String,
+        /**
+         * The description of the RBAC Role.
+         */
         @Json(name = "description")
         val description: String,
+        /**
+         * A list of permissions that link a [Resource](https://stytch.com/docs/b2b/api/rbac-resource-object) to a list of actions.
+         */
         @Json(name = "permissions")
         val permissions: List<PolicyRolePermission>,
     )
@@ -53,8 +135,28 @@ public data class PolicyRole
 public data class PolicyRolePermission
     @JvmOverloads
     constructor(
+        /**
+         * A unique identifier of the RBAC Resource, provided by the developer and intended to be human-readable.
+         *
+         *   A `resource_id` is not allowed to start with `stytch`, which is a special prefix used for Stytch default Resources
+         * with reserved  `resource_id`s. These include:
+         *
+         *   * `stytch.organization`
+         *   * `stytch.member`
+         *   * `stytch.sso`
+         *   * `stytch.self`
+         *
+         *   Check out the [guide on Stytch default Resources](https://stytch.com/docs/b2b/guides/rbac/stytch-defaults) for a more
+         * detailed explanation.
+         *
+         *
+         */
         @Json(name = "resource_id")
         val resourceId: String,
+        /**
+         * A list of permitted actions the Role is authorized to take with the provided Resource. You can use `*` as a wildcard to
+         * grant a Role permission to use all possible actions related to the Resource.
+         */
         @Json(name = "actions")
         val actions: List<String>,
     )
@@ -88,7 +190,7 @@ public data class PolicyResponse
         val statusCode: Int,
         /**
          * The RBAC Policy document that contains all defined Roles and Resources – which are managed in the
-         * [Dashboard](/dashboard). Read more about these entities and how they work in our
+         * [Dashboard](/dashboard/rbac). Read more about these entities and how they work in our
          * [RBAC overview](https://stytch.com/docs/b2b/guides/rbac/overview).
          */
         @Json(name = "policy")

--- a/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
@@ -1,3 +1,3 @@
 package com.stytch.java.common
 
-internal const val VERSION = "2.1.0"
+internal const val VERSION = "2.2.0"

--- a/stytch/src/main/kotlin/com/stytch/java/consumer/StytchClient.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/consumer/StytchClient.kt
@@ -32,6 +32,7 @@ import com.stytch.java.http.HttpClient
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import org.jose4j.jwk.HttpsJwks
+
 public object StytchClient {
     private lateinit var httpClient: HttpClient
     private lateinit var httpsJwks: HttpsJwks

--- a/stytch/src/main/kotlin/com/stytch/java/consumer/models/passwords/Passwords.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/consumer/models/passwords/Passwords.kt
@@ -503,6 +503,15 @@ public data class MigrateRequest
         @Json(name = "untrusted_metadata")
         val untrustedMetadata: Map<String, Any>? = null,
         /**
+         * Whether to set the user's email as verified. This is a dangerous field. Incorrect use may lead to users getting
+         * erroneously
+         *                 deduplicated into one user object. This flag should only be set if you can attest that the user owns
+         * the email address in question.
+         *                 Access to this field is restricted. To enable it, please send us a note at support@stytch.com.
+         */
+        @Json(name = "set_email_verified")
+        val setEmailVerified: Boolean? = null,
+        /**
          * The name of the user. Each field in the name object is optional.
          */
         @Json(name = "name")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,1 +1,1 @@
-version = "2.1.0"
+version = "2.2.0"


### PR DESCRIPTION
1. Docs updates
2. Adds support for `set_email_verified` in passwords/migrate