### PR TITLE
Ensure working B2B session claims

### DIFF
--- a/stytch/src/main/kotlin/com/stytch/java/common/StytchSessionClaim.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/common/StytchSessionClaim.kt
@@ -17,4 +17,6 @@ internal data class StytchSessionClaim(
     val attributes: Attributes?,
     @Json(name = "authentication_factors")
     val authenticationFactors: List<AuthenticationFactor>,
+    @Json(name = "roles")
+    val roles: List<String>? = null,
 )

--- a/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
@@ -1,3 +1,3 @@
 package com.stytch.java.common
 
-internal const val VERSION = "2.2.0"
+internal const val VERSION = "2.2.1"

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,1 +1,1 @@
-version = "2.2.0"
+version = "2.2.1"


### PR DESCRIPTION
[SDK-1483](https://linear.app/stytch/issue/SDK-1483)

Three things were happening here:
1. We were attempting to marshal the standard session claim (which doesn't include an organization ID) as a B2B session claim (which requires an organization ID)
2. We were trying to read the wrong name from the organization claim
3. Roles were missing from the regular session claim (which is what we want to parse the session claim as, and which does actually include those)

Validated in the workbench by validating a B2B JWT and getting a success response:
<img width="1599" alt="Screenshot 2024-02-13 at 12 32 11 PM" src="https://github.com/stytchauth/stytch-java/assets/117691317/46086c4f-c315-4764-aa55-ff891e7257f2">
