### PR TITLE
 Add B2B step-up docs and make email_id optional for OAuth factors

### DIFF
--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/discoveryintermediatesessions/DiscoveryIntermediateSessions.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/discoveryintermediatesessions/DiscoveryIntermediateSessions.kt
@@ -37,12 +37,11 @@ public data class ExchangeRequest
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
          * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization. It can also be used with the
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * specific Organization that allows the factors represented by the intermediate session token;
-         *     or the
+         * specific Organization that allows the factors represented by the intermediate session token; or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
          */
@@ -145,15 +144,14 @@ public data class ExchangeResponse
         @Json(name = "member_authenticated")
         val memberAuthenticated: Boolean,
         /**
-         * The returned Intermediate Session Token is identical to the one that was originally passed in to the request.
-         *         If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The
-         * token can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization. It can also be used with the
+         * The returned Intermediate Session Token is identical to the one that was originally passed in to the request. If this
+         * value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The token can be
+         * used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * specific Organization that allows the factors represented by the intermediate session token;
-         *     or the
+         * specific Organization that allows the factors represented by the intermediate session token; or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
          */

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/discoveryintermediatesessions/DiscoveryIntermediateSessions.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/discoveryintermediatesessions/DiscoveryIntermediateSessions.kt
@@ -35,14 +35,13 @@ public data class ExchangeRequest
     constructor(
         /**
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
-         * represents a bag of factors that may be converted to a member session.
-         *     The token can be used with the
+         * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
          *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow;
-         *     the [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join
-         * a specific Organization that allows the factors represented by the intermediate session token;
+         * flow and log in to the Organization. It can also be used with the
+         * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
+         * specific Organization that allows the factors represented by the intermediate session token;
          *     or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
@@ -147,17 +146,16 @@ public data class ExchangeResponse
         val memberAuthenticated: Boolean,
         /**
          * The returned Intermediate Session Token is identical to the one that was originally passed in to the request.
-         *       The token can be used with the
-         * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+         *         If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The
+         * token can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *       or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete the MFA
-         * flow and log in to the Organization.
-         *       It can also be used with the
+         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
+         * flow and log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * different existing Organization,
-         *       or the
+         * specific Organization that allows the factors represented by the intermediate session token;
+         *     or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
-         * create a new Organization.
+         * create a new Organization and Member.
          */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String,

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/discoveryorganizations/DiscoveryOrganizations.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/discoveryorganizations/DiscoveryOrganizations.kt
@@ -27,12 +27,11 @@ public data class CreateRequest
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
          * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization. It can also be used with the
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * specific Organization that allows the factors represented by the intermediate session token;
-         *     or the
+         * specific Organization that allows the factors represented by the intermediate session token; or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
          */
@@ -244,15 +243,14 @@ public data class CreateResponse
         @Json(name = "member_authenticated")
         val memberAuthenticated: Boolean,
         /**
-         * The returned Intermediate Session Token is identical to the one that was originally passed in to the request.
-         *         If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The
-         * token can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization. It can also be used with the
+         * The returned Intermediate Session Token is identical to the one that was originally passed in to the request. If this
+         * value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The token can be
+         * used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * specific Organization that allows the factors represented by the intermediate session token;
-         *     or the
+         * specific Organization that allows the factors represented by the intermediate session token; or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
          */
@@ -294,12 +292,11 @@ public data class ListRequest
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
          * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization. It can also be used with the
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * specific Organization that allows the factors represented by the intermediate session token;
-         *     or the
+         * specific Organization that allows the factors represented by the intermediate session token; or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
          */

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/discoveryorganizations/DiscoveryOrganizations.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/discoveryorganizations/DiscoveryOrganizations.kt
@@ -25,14 +25,13 @@ public data class CreateRequest
     constructor(
         /**
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
-         * represents a bag of factors that may be converted to a member session.
-         *     The token can be used with the
+         * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
          *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow;
-         *     the [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join
-         * a specific Organization that allows the factors represented by the intermediate session token;
+         * flow and log in to the Organization. It can also be used with the
+         * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
+         * specific Organization that allows the factors represented by the intermediate session token;
          *     or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
@@ -246,17 +245,16 @@ public data class CreateResponse
         val memberAuthenticated: Boolean,
         /**
          * The returned Intermediate Session Token is identical to the one that was originally passed in to the request.
-         *       The token can be used with the
-         * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+         *         If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The
+         * token can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *       or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete the MFA
-         * flow and log in to the Organization.
-         *       It can also be used with the
+         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
+         * flow and log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * different existing Organization,
-         *       or the
+         * specific Organization that allows the factors represented by the intermediate session token;
+         *     or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
-         * create a new Organization.
+         * create a new Organization and Member.
          */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String,
@@ -294,14 +292,13 @@ public data class ListRequest
     constructor(
         /**
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
-         * represents a bag of factors that may be converted to a member session.
-         *     The token can be used with the
+         * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
          *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow;
-         *     the [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join
-         * a specific Organization that allows the factors represented by the intermediate session token;
+         * flow and log in to the Organization. It can also be used with the
+         * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
+         * specific Organization that allows the factors represented by the intermediate session token;
          *     or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/magiclinks/MagicLinks.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/magiclinks/MagicLinks.kt
@@ -175,14 +175,13 @@ public data class AuthenticateResponse
         val organization: Organization,
         /**
          * The returned Intermediate Session Token contains an Email Magic Link factor associated with the Member's email address.
-         *         If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The
-         * token can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization. It can also be used with the
+         * If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The token
+         * can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * specific Organization that allows the factors represented by the intermediate session token;
-         *     or the
+         * specific Organization that allows the factors represented by the intermediate session token; or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
          */

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/magiclinks/MagicLinks.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/magiclinks/MagicLinks.kt
@@ -104,6 +104,12 @@ public data class AuthenticateRequest
          */
         @Json(name = "locale")
         val locale: AuthenticateRequestLocale? = null,
+        /**
+         * Adds this primary authentication factor to the intermediate session token. If the resulting set of factors
+         *        satisfies the organization's primary authentication requirements and MFA requirements, the intermediate session
+         *        token will be consumed and converted to a member session. If not, the same intermediate session token will be
+         *        returned.
+         */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String? = null,
     )
@@ -170,17 +176,16 @@ public data class AuthenticateResponse
         val organization: Organization,
         /**
          * The returned Intermediate Session Token contains an Email Magic Link factor associated with the Member's email address.
-         *       The token can be used with the
-         * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+         *         If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The
+         * token can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *       or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete the MFA
-         * flow and log in to the Organization.
-         *       It can also be used with the
+         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
+         * flow and log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * different existing Organization that allows login with Email Magic Links,
-         *       or the
+         * specific Organization that allows the factors represented by the intermediate session token;
+         *     or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
-         * create a new Organization.
+         * create a new Organization and Member.
          */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String,

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/magiclinks/MagicLinks.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/magiclinks/MagicLinks.kt
@@ -105,10 +105,9 @@ public data class AuthenticateRequest
         @Json(name = "locale")
         val locale: AuthenticateRequestLocale? = null,
         /**
-         * Adds this primary authentication factor to the intermediate session token. If the resulting set of factors
-         *        satisfies the organization's primary authentication requirements and MFA requirements, the intermediate session
-         *        token will be consumed and converted to a member session. If not, the same intermediate session token will be
-         *        returned.
+         * Adds this primary authentication factor to the intermediate session token. If the resulting set of factors satisfies
+         * the organization's primary authentication requirements and MFA requirements, the intermediate session token will be
+         * consumed and converted to a member session. If not, the same intermediate session token will be returned.
          */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String? = null,

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/magiclinksdiscovery/MagicLinksDiscovery.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/magiclinksdiscovery/MagicLinksDiscovery.kt
@@ -44,14 +44,13 @@ public data class AuthenticateResponse
         val requestId: String,
         /**
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
-         * represents a bag of factors that may be converted to a member session.
-         *     The token can be used with the
+         * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
          *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow;
-         *     the [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join
-         * a specific Organization that allows the factors represented by the intermediate session token;
+         * flow and log in to the Organization. It can also be used with the
+         * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
+         * specific Organization that allows the factors represented by the intermediate session token;
          *     or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/magiclinksdiscovery/MagicLinksDiscovery.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/magiclinksdiscovery/MagicLinksDiscovery.kt
@@ -46,12 +46,11 @@ public data class AuthenticateResponse
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
          * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization. It can also be used with the
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * specific Organization that allows the factors represented by the intermediate session token;
-         *     or the
+         * specific Organization that allows the factors represented by the intermediate session token; or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
          */

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/oauth/OAuth.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/oauth/OAuth.kt
@@ -202,15 +202,14 @@ public data class AuthenticateResponse
         @Json(name = "member_authenticated")
         val memberAuthenticated: Boolean,
         /**
-         * The returned Intermediate Session Token contains an OAuth factor associated with the Member's email address.
-         *         If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The
-         * token can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization. It can also be used with the
+         * The returned Intermediate Session Token contains an OAuth factor associated with the Member's email address. If this
+         * value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The token can be
+         * used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * specific Organization that allows the factors represented by the intermediate session token;
-         *     or the
+         * specific Organization that allows the factors represented by the intermediate session token; or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
          */

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/oauth/OAuth.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/oauth/OAuth.kt
@@ -129,6 +129,12 @@ public data class AuthenticateRequest
          */
         @Json(name = "locale")
         val locale: AuthenticateRequestLocale? = null,
+        /**
+         * Adds this primary authentication factor to the intermediate session token. If the resulting set of factors
+         *        satisfies the organization's primary authentication requirements and MFA requirements, the intermediate session
+         *        token will be consumed and converted to a member session. If not, the same intermediate session token will be
+         *        returned.
+         */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String? = null,
     )
@@ -198,17 +204,16 @@ public data class AuthenticateResponse
         val memberAuthenticated: Boolean,
         /**
          * The returned Intermediate Session Token contains an OAuth factor associated with the Member's email address.
-         *       The token can be used with the
-         * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+         *         If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The
+         * token can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *       or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete the MFA
-         * flow and log in to the Organization.
-         *       It can also be used with the
+         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
+         * flow and log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * different existing Organization that allows login with OAuth,
-         *       or the
+         * specific Organization that allows the factors represented by the intermediate session token;
+         *     or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
-         * create a new Organization.
+         * create a new Organization and Member.
          */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String,

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/oauth/OAuth.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/oauth/OAuth.kt
@@ -130,10 +130,9 @@ public data class AuthenticateRequest
         @Json(name = "locale")
         val locale: AuthenticateRequestLocale? = null,
         /**
-         * Adds this primary authentication factor to the intermediate session token. If the resulting set of factors
-         *        satisfies the organization's primary authentication requirements and MFA requirements, the intermediate session
-         *        token will be consumed and converted to a member session. If not, the same intermediate session token will be
-         *        returned.
+         * Adds this primary authentication factor to the intermediate session token. If the resulting set of factors satisfies
+         * the organization's primary authentication requirements and MFA requirements, the intermediate session token will be
+         * consumed and converted to a member session. If not, the same intermediate session token will be returned.
          */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String? = null,

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/oauthdiscovery/OAuthDiscovery.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/oauthdiscovery/OAuthDiscovery.kt
@@ -54,12 +54,11 @@ public data class AuthenticateResponse
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
          * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization. It can also be used with the
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * specific Organization that allows the factors represented by the intermediate session token;
-         *     or the
+         * specific Organization that allows the factors represented by the intermediate session token; or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
          */

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/oauthdiscovery/OAuthDiscovery.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/oauthdiscovery/OAuthDiscovery.kt
@@ -52,14 +52,13 @@ public data class AuthenticateResponse
         val requestId: String,
         /**
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
-         * represents a bag of factors that may be converted to a member session.
-         *     The token can be used with the
+         * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
          *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow;
-         *     the [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join
-         * a specific Organization that allows the factors represented by the intermediate session token;
+         * flow and log in to the Organization. It can also be used with the
+         * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
+         * specific Organization that allows the factors represented by the intermediate session token;
          *     or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/organizationsmembers/OrganizationsMembers.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/organizationsmembers/OrganizationsMembers.kt
@@ -691,10 +691,9 @@ public data class UpdateRequest
          * The name of the Member.
          *
          * If this field is provided and a session header is passed into the request, the Member Session must have permission to
-         * perform the `update.info.name` action on the `stytch.member` Resource.
-         *   Alternatively, if the Member Session matches the Member associated with the `member_id` passed in the request, the
-         * authorization check will also allow a Member Session that has permission to perform the `update.info.name` action on
-         * the `stytch.self` Resource.
+         * perform the `update.info.name` action on the `stytch.member` Resource. Alternatively, if the Member Session matches the
+         * Member associated with the `member_id` passed in the request, the authorization check will also allow a Member Session
+         * that has permission to perform the `update.info.name` action on the `stytch.self` Resource.
          */
         @Json(name = "name")
         val name: String? = null,
@@ -712,10 +711,10 @@ public data class UpdateRequest
          *   for complete field behavior details.
          *
          * If this field is provided and a session header is passed into the request, the Member Session must have permission to
-         * perform the `update.info.untrusted-metadata` action on the `stytch.member` Resource.
-         *   Alternatively, if the Member Session matches the Member associated with the `member_id` passed in the request, the
-         * authorization check will also allow a Member Session that has permission to perform the
-         * `update.info.untrusted-metadata` action on the `stytch.self` Resource.
+         * perform the `update.info.untrusted-metadata` action on the `stytch.member` Resource. Alternatively, if the Member
+         * Session matches the Member associated with the `member_id` passed in the request, the authorization check will also
+         * allow a Member Session that has permission to perform the `update.info.untrusted-metadata` action on the `stytch.self`
+         * Resource.
          */
         @Json(name = "untrusted_metadata")
         val untrustedMetadata: Map<String, Any?>? = emptyMap(),
@@ -736,10 +735,9 @@ public data class UpdateRequest
          * to delete the Member's existing phone number first.
          *
          * If this field is provided and a session header is passed into the request, the Member Session must have permission to
-         * perform the `update.info.mfa-phone` action on the `stytch.member` Resource.
-         *   Alternatively, if the Member Session matches the Member associated with the `member_id` passed in the request, the
-         * authorization check will also allow a Member Session that has permission to perform the `update.info.mfa-phone` action
-         * on the `stytch.self` Resource.
+         * perform the `update.info.mfa-phone` action on the `stytch.member` Resource. Alternatively, if the Member Session
+         * matches the Member associated with the `member_id` passed in the request, the authorization check will also allow a
+         * Member Session that has permission to perform the `update.info.mfa-phone` action on the `stytch.self` Resource.
          */
         @Json(name = "mfa_phone_number")
         val mfaPhoneNumber: String? = null,
@@ -749,10 +747,9 @@ public data class UpdateRequest
          * to `REQUIRED_FOR_ALL`.
          *
          * If this field is provided and a session header is passed into the request, the Member Session must have permission to
-         * perform the `update.settings.mfa-enrolled` action on the `stytch.member` Resource.
-         *   Alternatively, if the Member Session matches the Member associated with the `member_id` passed in the request, the
-         * authorization check will also allow a Member Session that has permission to perform the `update.settings.mfa-enrolled`
-         * action on the `stytch.self` Resource.
+         * perform the `update.settings.mfa-enrolled` action on the `stytch.member` Resource. Alternatively, if the Member Session
+         * matches the Member associated with the `member_id` passed in the request, the authorization check will also allow a
+         * Member Session that has permission to perform the `update.settings.mfa-enrolled` action on the `stytch.self` Resource.
          */
         @Json(name = "mfa_enrolled")
         val mfaEnrolled: Boolean? = null,
@@ -784,10 +781,10 @@ public data class UpdateRequest
          * to `REQUIRED_FOR_ALL`.
          *
          * If this field is provided and a session header is passed into the request, the Member Session must have permission to
-         * perform the `update.settings.default-mfa-method` action on the `stytch.member` Resource.
-         *   Alternatively, if the Member Session matches the Member associated with the `member_id` passed in the request, the
-         * authorization check will also allow a Member Session that has permission to perform the
-         * `update.settings.default-mfa-method` action on the `stytch.self` Resource.
+         * perform the `update.settings.default-mfa-method` action on the `stytch.member` Resource. Alternatively, if the Member
+         * Session matches the Member associated with the `member_id` passed in the request, the authorization check will also
+         * allow a Member Session that has permission to perform the `update.settings.default-mfa-method` action on the
+         * `stytch.self` Resource.
          */
         @Json(name = "default_mfa_method")
         val defaultMfaMethod: String? = null,

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/otpsms/OTPSms.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/otpsms/OTPSms.kt
@@ -50,14 +50,13 @@ public data class AuthenticateRequest
         val code: String,
         /**
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
-         * represents a bag of factors that may be converted to a member session.
-         *     The token can be used with the
+         * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
          *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow;
-         *     the [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join
-         * a specific Organization that allows the factors represented by the intermediate session token;
+         * flow and log in to the Organization. It can also be used with the
+         * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
+         * specific Organization that allows the factors represented by the intermediate session token;
          *     or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
@@ -210,14 +209,13 @@ public data class SendRequest
         val locale: SendRequestLocale? = null,
         /**
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
-         * represents a bag of factors that may be converted to a member session.
-         *     The token can be used with the
+         * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
          *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow;
-         *     the [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join
-         * a specific Organization that allows the factors represented by the intermediate session token;
+         * flow and log in to the Organization. It can also be used with the
+         * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
+         * specific Organization that allows the factors represented by the intermediate session token;
          *     or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/otpsms/OTPSms.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/otpsms/OTPSms.kt
@@ -52,12 +52,11 @@ public data class AuthenticateRequest
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
          * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization. It can also be used with the
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * specific Organization that allows the factors represented by the intermediate session token;
-         *     or the
+         * specific Organization that allows the factors represented by the intermediate session token; or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
          */
@@ -211,12 +210,11 @@ public data class SendRequest
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
          * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization. It can also be used with the
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * specific Organization that allows the factors represented by the intermediate session token;
-         *     or the
+         * specific Organization that allows the factors represented by the intermediate session token; or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
          */

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwords/Passwords.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwords/Passwords.kt
@@ -190,6 +190,12 @@ public data class AuthenticateRequest
          */
         @Json(name = "locale")
         val locale: AuthenticateRequestLocale? = null,
+        /**
+         * Adds this primary authentication factor to the intermediate session token. If the resulting set of factors
+         *        satisfies the organization's primary authentication requirements and MFA requirements, the intermediate session
+         *        token will be consumed and converted to a member session. If not, the same intermediate session token will be
+         *        returned.
+         */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String? = null,
     )
@@ -240,12 +246,12 @@ public data class AuthenticateResponse
         val organization: Organization,
         /**
          * The returned Intermediate Session Token contains a password factor associated with the Member.
-         *       The token can be used with the
-         * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+         *         If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The
+         * token can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *       or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete the MFA
+         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
          * flow and log in to the Organization.
-         *       Password factors are not transferable between Organizations, so the intermediate session token is not valid for
+         *         Password factors are not transferable between Organizations, so the intermediate session token is not valid for
          * use with discovery endpoints.
          */
         @Json(name = "intermediate_session_token")

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwords/Passwords.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwords/Passwords.kt
@@ -191,10 +191,9 @@ public data class AuthenticateRequest
         @Json(name = "locale")
         val locale: AuthenticateRequestLocale? = null,
         /**
-         * Adds this primary authentication factor to the intermediate session token. If the resulting set of factors
-         *        satisfies the organization's primary authentication requirements and MFA requirements, the intermediate session
-         *        token will be consumed and converted to a member session. If not, the same intermediate session token will be
-         *        returned.
+         * Adds this primary authentication factor to the intermediate session token. If the resulting set of factors satisfies
+         * the organization's primary authentication requirements and MFA requirements, the intermediate session token will be
+         * consumed and converted to a member session. If not, the same intermediate session token will be returned.
          */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String? = null,

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwords/Passwords.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwords/Passwords.kt
@@ -244,14 +244,13 @@ public data class AuthenticateResponse
         @Json(name = "organization")
         val organization: Organization,
         /**
-         * The returned Intermediate Session Token contains a password factor associated with the Member.
-         *         If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The
-         * token can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization.
-         *         Password factors are not transferable between Organizations, so the intermediate session token is not valid for
-         * use with discovery endpoints.
+         * The returned Intermediate Session Token contains a password factor associated with the Member. If this value is
+         * non-empty, the member must complete an MFA step to finish logging in to the Organization. The token can be used with
+         * the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. Password factors are not transferable between Organizations, so the intermediate session
+         * token is not valid for use with discovery endpoints.
          */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String,

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwordsemail/PasswordsEmail.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwordsemail/PasswordsEmail.kt
@@ -121,6 +121,12 @@ public data class ResetRequest
          */
         @Json(name = "locale")
         val locale: ResetRequestLocale? = null,
+        /**
+         * Adds this primary authentication factor to the intermediate session token. If the resulting set of factors
+         *        satisfies the organization's primary authentication requirements and MFA requirements, the intermediate session
+         *        token will be consumed and converted to a member session. If not, the same intermediate session token will be
+         *        returned.
+         */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String? = null,
     )
@@ -176,12 +182,12 @@ public data class ResetResponse
         val organization: Organization,
         /**
          * The returned Intermediate Session Token contains a password factor associated with the Member.
-         *       The token can be used with the
-         * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+         *         If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The
+         * token can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *       or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete the MFA
+         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
          * flow and log in to the Organization.
-         *       Password factors are not transferable between Organizations, so the intermediate session token is not valid for
+         *         Password factors are not transferable between Organizations, so the intermediate session token is not valid for
          * use with discovery endpoints.
          */
         @Json(name = "intermediate_session_token")

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwordsemail/PasswordsEmail.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwordsemail/PasswordsEmail.kt
@@ -180,14 +180,13 @@ public data class ResetResponse
         @Json(name = "organization")
         val organization: Organization,
         /**
-         * The returned Intermediate Session Token contains a password factor associated with the Member.
-         *         If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The
-         * token can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization.
-         *         Password factors are not transferable between Organizations, so the intermediate session token is not valid for
-         * use with discovery endpoints.
+         * The returned Intermediate Session Token contains a password factor associated with the Member. If this value is
+         * non-empty, the member must complete an MFA step to finish logging in to the Organization. The token can be used with
+         * the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. Password factors are not transferable between Organizations, so the intermediate session
+         * token is not valid for use with discovery endpoints.
          */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String,

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwordsemail/PasswordsEmail.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwordsemail/PasswordsEmail.kt
@@ -122,10 +122,9 @@ public data class ResetRequest
         @Json(name = "locale")
         val locale: ResetRequestLocale? = null,
         /**
-         * Adds this primary authentication factor to the intermediate session token. If the resulting set of factors
-         *        satisfies the organization's primary authentication requirements and MFA requirements, the intermediate session
-         *        token will be consumed and converted to a member session. If not, the same intermediate session token will be
-         *        returned.
+         * Adds this primary authentication factor to the intermediate session token. If the resulting set of factors satisfies
+         * the organization's primary authentication requirements and MFA requirements, the intermediate session token will be
+         * consumed and converted to a member session. If not, the same intermediate session token will be returned.
          */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String? = null,

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwordsexistingpassword/PasswordsExistingPassword.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwordsexistingpassword/PasswordsExistingPassword.kt
@@ -149,12 +149,12 @@ public data class ResetResponse
         val organization: Organization,
         /**
          * The returned Intermediate Session Token contains a password factor associated with the Member.
-         *       The token can be used with the
-         * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+         *         If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The
+         * token can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *       or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete the MFA
+         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
          * flow and log in to the Organization.
-         *       Password factors are not transferable between Organizations, so the intermediate session token is not valid for
+         *         Password factors are not transferable between Organizations, so the intermediate session token is not valid for
          * use with discovery endpoints.
          */
         @Json(name = "intermediate_session_token")

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwordsexistingpassword/PasswordsExistingPassword.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwordsexistingpassword/PasswordsExistingPassword.kt
@@ -148,14 +148,13 @@ public data class ResetResponse
         @Json(name = "organization")
         val organization: Organization,
         /**
-         * The returned Intermediate Session Token contains a password factor associated with the Member.
-         *         If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The
-         * token can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization.
-         *         Password factors are not transferable between Organizations, so the intermediate session token is not valid for
-         * use with discovery endpoints.
+         * The returned Intermediate Session Token contains a password factor associated with the Member. If this value is
+         * non-empty, the member must complete an MFA step to finish logging in to the Organization. The token can be used with
+         * the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. Password factors are not transferable between Organizations, so the intermediate session
+         * token is not valid for use with discovery endpoints.
          */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String,

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwordssession/PasswordsSession.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwordssession/PasswordsSession.kt
@@ -138,12 +138,11 @@ public data class ResetResponse
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
          * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization. It can also be used with the
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * specific Organization that allows the factors represented by the intermediate session token;
-         *     or the
+         * specific Organization that allows the factors represented by the intermediate session token; or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
          */

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwordssession/PasswordsSession.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwordssession/PasswordsSession.kt
@@ -136,14 +136,13 @@ public data class ResetResponse
         val sessionJwt: String,
         /**
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
-         * represents a bag of factors that may be converted to a member session.
-         *     The token can be used with the
+         * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
          *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow;
-         *     the [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join
-         * a specific Organization that allows the factors represented by the intermediate session token;
+         * flow and log in to the Organization. It can also be used with the
+         * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
+         * specific Organization that allows the factors represented by the intermediate session token;
          *     or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/recoverycodes/RecoveryCodes.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/recoverycodes/RecoveryCodes.kt
@@ -103,12 +103,11 @@ public data class RecoverRequest
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
          * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization. It can also be used with the
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * specific Organization that allows the factors represented by the intermediate session token;
-         *     or the
+         * specific Organization that allows the factors represented by the intermediate session token; or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
          */

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/recoverycodes/RecoveryCodes.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/recoverycodes/RecoveryCodes.kt
@@ -101,14 +101,13 @@ public data class RecoverRequest
         val recoveryCode: String,
         /**
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
-         * represents a bag of factors that may be converted to a member session.
-         *     The token can be used with the
+         * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
          *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow;
-         *     the [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join
-         * a specific Organization that allows the factors represented by the intermediate session token;
+         * flow and log in to the Organization. It can also be used with the
+         * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
+         * specific Organization that allows the factors represented by the intermediate session token;
          *     or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/sessions/Sessions.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/sessions/Sessions.kt
@@ -376,17 +376,16 @@ public data class ExchangeResponse
         /**
          * The returned Intermediate Session Token contains any Email Magic Link or OAuth factors from the original member session
          * that are valid for the target Organization.
-         *       The token can be used with the
-         * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+         *         If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The
+         * token can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *       or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete the MFA
-         * flow and log in to the target Organization.
-         *       It can also be used with the
+         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
+         * flow and log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * different existing Organization,
-         *       or the
+         * specific Organization that allows the factors represented by the intermediate session token;
+         *     or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
-         * create a new Organization.
+         * create a new Organization and Member.
          */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String,

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/sessions/Sessions.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/sessions/Sessions.kt
@@ -375,15 +375,14 @@ public data class ExchangeResponse
         val memberAuthenticated: Boolean,
         /**
          * The returned Intermediate Session Token contains any Email Magic Link or OAuth factors from the original member session
-         * that are valid for the target Organization.
-         *         If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The
-         * token can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization. It can also be used with the
+         * that are valid for the target Organization. If this value is non-empty, the member must complete an MFA step to finish
+         * logging in to the Organization. The token can be used with the
+         * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * specific Organization that allows the factors represented by the intermediate session token;
-         *     or the
+         * specific Organization that allows the factors represented by the intermediate session token; or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
          */

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/sso/SSO.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/sso/SSO.kt
@@ -263,6 +263,12 @@ public data class AuthenticateRequest
          */
         @Json(name = "locale")
         val locale: AuthenticateRequestLocale? = null,
+        /**
+         * Adds this primary authentication factor to the intermediate session token. If the resulting set of factors
+         *        satisfies the organization's primary authentication requirements and MFA requirements, the intermediate session
+         *        token will be consumed and converted to a member session. If not, the same intermediate session token will be
+         *        returned.
+         */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String? = null,
     )
@@ -319,12 +325,12 @@ public data class AuthenticateResponse
         val organization: Organization,
         /**
          * The returned Intermediate Session Token contains an SSO factor associated with the Member.
-         *       The token can be used with the
-         * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+         *         If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The
+         * token can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *       or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete the MFA
+         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
          * flow and log in to the Organization.
-         *       SSO factors are not transferable between Organizations, so the intermediate session token is not valid for use
+         *         SSO factors are not transferable between Organizations, so the intermediate session token is not valid for use
          * with discovery endpoints.
          */
         @Json(name = "intermediate_session_token")

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/sso/SSO.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/sso/SSO.kt
@@ -264,10 +264,9 @@ public data class AuthenticateRequest
         @Json(name = "locale")
         val locale: AuthenticateRequestLocale? = null,
         /**
-         * Adds this primary authentication factor to the intermediate session token. If the resulting set of factors
-         *        satisfies the organization's primary authentication requirements and MFA requirements, the intermediate session
-         *        token will be consumed and converted to a member session. If not, the same intermediate session token will be
-         *        returned.
+         * Adds this primary authentication factor to the intermediate session token. If the resulting set of factors satisfies
+         * the organization's primary authentication requirements and MFA requirements, the intermediate session token will be
+         * consumed and converted to a member session. If not, the same intermediate session token will be returned.
          */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String? = null,

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/sso/SSO.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/sso/SSO.kt
@@ -323,14 +323,13 @@ public data class AuthenticateResponse
         @Json(name = "organization")
         val organization: Organization,
         /**
-         * The returned Intermediate Session Token contains an SSO factor associated with the Member.
-         *         If this value is non-empty, the member must complete an MFA step to finish logging in to the Organization. The
-         * token can be used with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization.
-         *         SSO factors are not transferable between Organizations, so the intermediate session token is not valid for use
-         * with discovery endpoints.
+         * The returned Intermediate Session Token contains an SSO factor associated with the Member. If this value is non-empty,
+         * the member must complete an MFA step to finish logging in to the Organization. The token can be used with the
+         * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. SSO factors are not transferable between Organizations, so the intermediate session token
+         * is not valid for use with discovery endpoints.
          */
         @Json(name = "intermediate_session_token")
         val intermediateSessionToken: String,

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/totps/TOTPs.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/totps/TOTPs.kt
@@ -40,12 +40,11 @@ public data class AuthenticateRequest
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
          * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization. It can also be used with the
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * specific Organization that allows the factors represented by the intermediate session token;
-         *     or the
+         * specific Organization that allows the factors represented by the intermediate session token; or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
          */
@@ -193,12 +192,11 @@ public data class CreateRequest
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
          * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
-         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
-         *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow and log in to the Organization. It can also be used with the
+         * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+         * [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA flow and
+         * log in to the Organization. It can also be used with the
          * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
-         * specific Organization that allows the factors represented by the intermediate session token;
-         *     or the
+         * specific Organization that allows the factors represented by the intermediate session token; or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
          */

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/totps/TOTPs.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/totps/TOTPs.kt
@@ -38,14 +38,13 @@ public data class AuthenticateRequest
         val code: String,
         /**
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
-         * represents a bag of factors that may be converted to a member session.
-         *     The token can be used with the
+         * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
          *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow;
-         *     the [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join
-         * a specific Organization that allows the factors represented by the intermediate session token;
+         * flow and log in to the Organization. It can also be used with the
+         * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
+         * specific Organization that allows the factors represented by the intermediate session token;
          *     or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.
@@ -192,14 +191,13 @@ public data class CreateRequest
         val expirationMinutes: Int? = null,
         /**
          * The Intermediate Session Token. This token does not necessarily belong to a specific instance of a Member, but
-         * represents a bag of factors that may be converted to a member session.
-         *     The token can be used with the
+         * represents a bag of factors that may be converted to a member session. The token can be used with the
          * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
          * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
          *     or [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an MFA
-         * flow;
-         *     the [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join
-         * a specific Organization that allows the factors represented by the intermediate session token;
+         * flow and log in to the Organization. It can also be used with the
+         * [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session) to join a
+         * specific Organization that allows the factors represented by the intermediate session token;
          *     or the
          * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to
          * create a new Organization and Member.

--- a/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
@@ -1,3 +1,3 @@
 package com.stytch.java.common
 
-internal const val VERSION = "3.0.0"
+internal const val VERSION = "3.1.0"

--- a/stytch/src/main/kotlin/com/stytch/java/consumer/models/sessions/Sessions.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/consumer/models/sessions/Sessions.kt
@@ -174,10 +174,10 @@ public data class AmazonOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -186,10 +186,10 @@ public data class AppleOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -353,10 +353,10 @@ public data class BitbucketOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -365,10 +365,10 @@ public data class CoinbaseOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -389,10 +389,10 @@ public data class DiscordOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -425,10 +425,10 @@ public data class FacebookOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -437,10 +437,10 @@ public data class FigmaOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -449,10 +449,10 @@ public data class GitLabOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -461,10 +461,10 @@ public data class GithubOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -477,16 +477,16 @@ public data class GoogleOAuthFactor
         @Json(name = "id")
         val id: String,
         /**
-         * The globally unique UUID of the Member's email.
-         */
-        @Json(name = "email_id")
-        val emailId: String,
-        /**
          * The unique identifier for the User within a given OAuth provider. Also commonly called the `sub` or "Subject field" in
          * OAuth protocols.
          */
         @Json(name = "provider_subject")
         val providerSubject: String,
+        /**
+         * The globally unique UUID of the Member's email.
+         */
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -503,10 +503,10 @@ public data class HubspotOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -515,10 +515,10 @@ public data class InstagramOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -551,10 +551,10 @@ public data class LinkedInOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -567,16 +567,16 @@ public data class MicrosoftOAuthFactor
         @Json(name = "id")
         val id: String,
         /**
-         * The globally unique UUID of the Member's email.
-         */
-        @Json(name = "email_id")
-        val emailId: String,
-        /**
          * The unique identifier for the User within a given OAuth provider. Also commonly called the `sub` or "Subject field" in
          * OAuth protocols.
          */
         @Json(name = "provider_subject")
         val providerSubject: String,
+        /**
+         * The globally unique UUID of the Member's email.
+         */
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -651,10 +651,10 @@ public data class SalesforceOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -712,10 +712,10 @@ public data class ShopifyOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -732,10 +732,10 @@ public data class SlackOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -744,10 +744,10 @@ public data class SnapchatOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -756,10 +756,10 @@ public data class SpotifyOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -768,10 +768,10 @@ public data class SteamOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -780,10 +780,10 @@ public data class TikTokOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -792,10 +792,10 @@ public data class TwitchOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -804,10 +804,10 @@ public data class TwitterOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 @JsonClass(generateAdapter = true)
@@ -828,10 +828,10 @@ public data class YahooOAuthFactor
     constructor(
         @Json(name = "id")
         val id: String,
-        @Json(name = "email_id")
-        val emailId: String,
         @Json(name = "provider_subject")
         val providerSubject: String,
+        @Json(name = "email_id")
+        val emailId: String? = null,
     )
 
 /**

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,1 +1,1 @@
-version = "3.0.0"
+version = "3.1.0"


### PR DESCRIPTION
This PR pulls in various changes, but mostly includes docs updates for B2B step-up, and a fix for `email_id` being marked as required for OAuth factors.