### PR TITLE
Change MicrosoftRequest to ProviderInformationRequest

### DIFF
--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/organizationsmembersoauthproviders/OrganizationsMembersOAuthProviders.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/organizationsmembersoauthproviders/OrganizationsMembersOAuthProviders.kt
@@ -10,8 +10,8 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
 import com.stytch.java.b2b.models.organizationsmembersoauthproviders.GoogleResponse
-import com.stytch.java.b2b.models.organizationsmembersoauthproviders.MicrosoftRequest
 import com.stytch.java.b2b.models.organizationsmembersoauthproviders.MicrosoftResponse
+import com.stytch.java.b2b.models.organizationsmembersoauthproviders.ProviderInformationRequest
 import com.stytch.java.common.InstantAdapter
 import com.stytch.java.common.StytchResult
 import com.stytch.java.http.HttpClient
@@ -34,7 +34,7 @@ public interface OAuthProviders {
      * To force a refresh token to be issued, pass the `?provider_prompt=consent` query param into the
      * [Start Google OAuth flow](https://stytch.com/docs/b2b/api/oauth-google-start) endpoint.
      */
-    public suspend fun google(data: MicrosoftRequest): StytchResult<GoogleResponse>
+    public suspend fun google(data: ProviderInformationRequest): StytchResult<GoogleResponse>
 
     /**
      * Retrieve the saved Google access token and ID token for a member. After a successful OAuth login, Stytch will save the
@@ -47,7 +47,7 @@ public interface OAuthProviders {
      * [Start Google OAuth flow](https://stytch.com/docs/b2b/api/oauth-google-start) endpoint.
      */
     public fun google(
-        data: MicrosoftRequest,
+        data: ProviderInformationRequest,
         callback: (StytchResult<GoogleResponse>) -> Unit,
     )
 
@@ -61,7 +61,7 @@ public interface OAuthProviders {
      * To force a refresh token to be issued, pass the `?provider_prompt=consent` query param into the
      * [Start Google OAuth flow](https://stytch.com/docs/b2b/api/oauth-google-start) endpoint.
      */
-    public fun googleCompletable(data: MicrosoftRequest): CompletableFuture<StytchResult<GoogleResponse>>
+    public fun googleCompletable(data: ProviderInformationRequest): CompletableFuture<StytchResult<GoogleResponse>>
 
     /**
      * Retrieve the saved Microsoft access token and ID token for a member. After a successful OAuth login, Stytch will save
@@ -69,7 +69,7 @@ public interface OAuthProviders {
      * issued access token and ID token from the identity provider. If a refresh token has been issued, Stytch will refresh the
      * access token automatically.
      */
-    public suspend fun microsoft(data: MicrosoftRequest): StytchResult<MicrosoftResponse>
+    public suspend fun microsoft(data: ProviderInformationRequest): StytchResult<MicrosoftResponse>
 
     /**
      * Retrieve the saved Microsoft access token and ID token for a member. After a successful OAuth login, Stytch will save
@@ -78,7 +78,7 @@ public interface OAuthProviders {
      * access token automatically.
      */
     public fun microsoft(
-        data: MicrosoftRequest,
+        data: ProviderInformationRequest,
         callback: (StytchResult<MicrosoftResponse>) -> Unit,
     )
 
@@ -88,7 +88,7 @@ public interface OAuthProviders {
      * issued access token and ID token from the identity provider. If a refresh token has been issued, Stytch will refresh the
      * access token automatically.
      */
-    public fun microsoftCompletable(data: MicrosoftRequest): CompletableFuture<StytchResult<MicrosoftResponse>>
+    public fun microsoftCompletable(data: ProviderInformationRequest): CompletableFuture<StytchResult<MicrosoftResponse>>
 }
 
 internal class OAuthProvidersImpl(
@@ -97,11 +97,11 @@ internal class OAuthProvidersImpl(
 ) : OAuthProviders {
     private val moshi = Moshi.Builder().add(InstantAdapter()).build()
 
-    override suspend fun google(data: MicrosoftRequest): StytchResult<GoogleResponse> =
+    override suspend fun google(data: ProviderInformationRequest): StytchResult<GoogleResponse> =
         withContext(Dispatchers.IO) {
             var headers = emptyMap<String, String>()
 
-            val asJson = moshi.adapter(MicrosoftRequest::class.java).toJson(data)
+            val asJson = moshi.adapter(ProviderInformationRequest::class.java).toJson(data)
             val type = Types.newParameterizedType(Map::class.java, String::class.java, Any::class.java)
             val adapter: JsonAdapter<Map<String, Any>> = moshi.adapter(type)
             val asMap = adapter.fromJson(asJson) ?: emptyMap()
@@ -109,7 +109,7 @@ internal class OAuthProvidersImpl(
         }
 
     override fun google(
-        data: MicrosoftRequest,
+        data: ProviderInformationRequest,
         callback: (StytchResult<GoogleResponse>) -> Unit,
     ) {
         coroutineScope.launch {
@@ -117,16 +117,16 @@ internal class OAuthProvidersImpl(
         }
     }
 
-    override fun googleCompletable(data: MicrosoftRequest): CompletableFuture<StytchResult<GoogleResponse>> =
+    override fun googleCompletable(data: ProviderInformationRequest): CompletableFuture<StytchResult<GoogleResponse>> =
         coroutineScope.async {
             google(data)
         }.asCompletableFuture()
 
-    override suspend fun microsoft(data: MicrosoftRequest): StytchResult<MicrosoftResponse> =
+    override suspend fun microsoft(data: ProviderInformationRequest): StytchResult<MicrosoftResponse> =
         withContext(Dispatchers.IO) {
             var headers = emptyMap<String, String>()
 
-            val asJson = moshi.adapter(MicrosoftRequest::class.java).toJson(data)
+            val asJson = moshi.adapter(ProviderInformationRequest::class.java).toJson(data)
             val type = Types.newParameterizedType(Map::class.java, String::class.java, Any::class.java)
             val adapter: JsonAdapter<Map<String, Any>> = moshi.adapter(type)
             val asMap = adapter.fromJson(asJson) ?: emptyMap()
@@ -138,7 +138,7 @@ internal class OAuthProvidersImpl(
         }
 
     override fun microsoft(
-        data: MicrosoftRequest,
+        data: ProviderInformationRequest,
         callback: (StytchResult<MicrosoftResponse>) -> Unit,
     ) {
         coroutineScope.launch {
@@ -146,7 +146,7 @@ internal class OAuthProvidersImpl(
         }
     }
 
-    override fun microsoftCompletable(data: MicrosoftRequest): CompletableFuture<StytchResult<MicrosoftResponse>> =
+    override fun microsoftCompletable(data: ProviderInformationRequest): CompletableFuture<StytchResult<MicrosoftResponse>> =
         coroutineScope.async {
             microsoft(data)
         }.asCompletableFuture()

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/organizationsmembersoauthproviders/OrganizationsMembersOAuthProviders.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/organizationsmembersoauthproviders/OrganizationsMembersOAuthProviders.kt
@@ -70,33 +70,6 @@ public data class GoogleResponse
     )
 
 /**
-* Request type for `OAuthProviders.google`, `OAuthProviders.microsoft`.
-*/
-@JsonClass(generateAdapter = true)
-public data class MicrosoftRequest
-    @JvmOverloads
-    constructor(
-        /**
-         * Globally unique UUID that identifies a specific Organization. The `organization_id` is critical to perform operations
-         * on an Organization, so be sure to preserve this value.
-         */
-        @Json(name = "organization_id")
-        val organizationId: String,
-        /**
-         * Globally unique UUID that identifies a specific Member. The `member_id` is critical to perform operations on a Member,
-         * so be sure to preserve this value.
-         */
-        @Json(name = "member_id")
-        val memberId: String,
-        /**
-         * Whether to return the refresh token Stytch has stored for the OAuth Provider. Defaults to false. **Important:** If your
-         * application exchanges the refresh token, Stytch may not be able to automatically refresh access tokens in the future.
-         */
-        @Json(name = "include_refresh_token")
-        val includeRefreshToken: Boolean? = null,
-    )
-
-/**
 * Response type for `OAuthProviders.microsoft`.
 */
 @JsonClass(generateAdapter = true)
@@ -154,4 +127,31 @@ public data class MicrosoftResponse
          */
         @Json(name = "refresh_token")
         val refreshToken: String? = null,
+    )
+
+/**
+* Request type for `OAuthProviders.google`, `OAuthProviders.microsoft`.
+*/
+@JsonClass(generateAdapter = true)
+public data class ProviderInformationRequest
+    @JvmOverloads
+    constructor(
+        /**
+         * Globally unique UUID that identifies a specific Organization. The `organization_id` is critical to perform operations
+         * on an Organization, so be sure to preserve this value.
+         */
+        @Json(name = "organization_id")
+        val organizationId: String,
+        /**
+         * Globally unique UUID that identifies a specific Member. The `member_id` is critical to perform operations on a Member,
+         * so be sure to preserve this value.
+         */
+        @Json(name = "member_id")
+        val memberId: String,
+        /**
+         * Whether to return the refresh token Stytch has stored for the OAuth Provider. Defaults to false. **Important:** If your
+         * application exchanges the refresh token, Stytch may not be able to automatically refresh access tokens in the future.
+         */
+        @Json(name = "include_refresh_token")
+        val includeRefreshToken: Boolean? = null,
     )

--- a/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
@@ -1,3 +1,3 @@
 package com.stytch.java.common
 
-internal const val VERSION = "3.1.0"
+internal const val VERSION = "4.0.0"

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,1 +1,1 @@
-version = "3.1.0"
+version = "4.0.0"


### PR DESCRIPTION
I know we just had a major version bump, but unfortunately...we're going to have to do it again, because we need to change the name `MicrosoftRequest` to `ProviderInformationRequest` since it's not just used for Microsoft.