### PR TITLE
Support wildcard scopes in M2M auth

### DIFF
--- a/stytch/src/main/kotlin/com/stytch/java/b2b/StytchB2BClient.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/StytchB2BClient.kt
@@ -41,6 +41,7 @@ import com.stytch.java.http.HttpClient
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import org.jose4j.jwk.HttpsJwks
+
 public object StytchB2BClient {
     private lateinit var httpClient: HttpClient
     private lateinit var httpsJwks: HttpsJwks

--- a/stytch/src/main/kotlin/com/stytch/java/common/JWTException.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/common/JWTException.kt
@@ -14,7 +14,11 @@ public sealed class JWTException(
 
     public object MissingRolesClaim : JWTException(reason = "Missing roles claim field")
 
-    public data class JwtMissingScopes(val missingScopes: List<String>) : JWTException(
-        reason = "Missing required scopes: $missingScopes",
+    public data class JwtMissingAction(val action: String) : JWTException(
+        reason = "Missing required action: $action",
+    )
+
+    public data class JwtMissingScope(val missingScope: String) : JWTException(
+        reason = "Missing required scope: $missingScope",
     )
 }

--- a/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
@@ -1,3 +1,3 @@
 package com.stytch.java.common
 
-internal const val VERSION = "5.0.0"
+internal const val VERSION = "5.1.0"

--- a/stytch/src/main/kotlin/com/stytch/java/consumer/StytchClient.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/consumer/StytchClient.kt
@@ -34,6 +34,7 @@ import com.stytch.java.http.HttpClient
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import org.jose4j.jwk.HttpsJwks
+
 public object StytchClient {
     private lateinit var httpClient: HttpClient
     private lateinit var httpsJwks: HttpsJwks

--- a/stytch/src/main/kotlin/com/stytch/java/consumer/api/m2m/M2M.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/consumer/api/m2m/M2M.kt
@@ -254,31 +254,26 @@ internal class M2MImpl(
             requiredScopes: List<String>,
         ) {
             val clientScopes: MutableMap<String, MutableSet<String>> = mutableMapOf()
-            for (scope in hasScopes) {
-                var action = scope
-                var resource = "-"
-                if (":" in scope) {
-                    val (splitAction, splitResource) = scope.split(":")
-                    action = splitAction
-                    resource = splitResource
-                }
+            hasScopes.forEach { scope ->
+                val (action, resource) =
+                    if (scope.contains(":")) {
+                        scope.split(":")
+                    } else {
+                        listOf(scope, "-")
+                    }
                 clientScopes.computeIfAbsent(action) { mutableSetOf() }.add(resource)
             }
 
-            for (requiredScope in requiredScopes) {
-                var requiredAction = requiredScope
-                var requiredResource = "-"
-                if (":" in requiredScope) {
-                    val (splitAction, splitResource) = requiredScope.split(":")
-                    requiredAction = splitAction
-                    requiredResource = splitResource
-                }
-                val resources =
-                    clientScopes[requiredAction] ?: throw JWTException.JwtMissingAction(requiredAction)
-
-                // The client can either have a wildcard resource or the specific resource
+            requiredScopes.forEach { scope ->
+                val (requiredAction, requiredResource) =
+                    if (scope.contains(":")) {
+                        scope.split(":")
+                    } else {
+                        listOf(scope, "-")
+                    }
+                val resources = clientScopes[requiredAction] ?: throw JWTException.JwtMissingAction(requiredAction)
                 if ("*" !in resources && requiredResource !in resources) {
-                    throw JWTException.JwtMissingScope(requiredScope)
+                    throw JWTException.JwtMissingScope(scope)
                 }
             }
         }

--- a/stytch/src/main/kotlin/com/stytch/java/consumer/api/m2m/M2M.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/consumer/api/m2m/M2M.kt
@@ -256,7 +256,7 @@ internal class M2MImpl(
             val clientScopes: MutableMap<String, MutableSet<String>> = mutableMapOf()
             for (scope in hasScopes) {
                 var action = scope
-                var resource = "*"
+                var resource = "-"
                 if (":" in scope) {
                     val (splitAction, splitResource) = scope.split(":")
                     action = splitAction
@@ -267,7 +267,7 @@ internal class M2MImpl(
 
             for (requiredScope in requiredScopes) {
                 var requiredAction = requiredScope
-                var requiredResource = "*"
+                var requiredResource = "-"
                 if (":" in requiredScope) {
                     val (splitAction, splitResource) = requiredScope.split(":")
                     requiredAction = splitAction

--- a/stytch/src/main/kotlin/com/stytch/java/consumer/api/m2m/M2M.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/consumer/api/m2m/M2M.kt
@@ -40,48 +40,48 @@ public interface M2M {
     // ADDIMPORT: import okhttp3.MediaType.Companion.toMediaType
 
     /**
-     * Token retrieves an access token for the given M2M Client.
-     * Access tokens are JWTs signed with the project's JWKs, and are valid for one hour after issuance.
-     * M2M Access tokens contain a standard set of claims as well as any custom claims generated from templates.
-     * M2M Access tokens can be validated locally using the Authenticate Access Token method in the Stytch Backend SDKs,
+     * Token retrieves an access token for the given M2M Client. Access tokens are JWTs signed with
+     * the project's JWKs, and are valid for one hour after issuance. M2M Access tokens contain a
+     * standard set of claims as well as any custom claims generated from templates. M2M Access tokens
+     * can be validated locally using the Authenticate Access Token method in the Stytch Backend SDKs,
      * or with any library that supports JWT signature validation.
      *
      * Here is an example of a standard set of claims from a M2M Access Token:
      * ```
      *
-     *	{
-     *	  "sub": "m2m-client-test-d731954d-dab3-4a2b-bdee-07f3ad1be885",
-     *	  "iss": "stytch.com/project-test-3e71d0a1-1e3e-4ee2-9be0-d7c0900f02c2",
-     *	  "aud": ["project-test-3e71d0a1-1e3e-4ee2-9be0-d7c0900f02c2"],
-     *	  "scope": "read:users write:users",
-     *	  "iat": 4102473300,
-     *	  "nbf": 4102473300,
-     *	  "exp": 4102476900
-     *	}
+     * 	{
+     * 	  "sub": "m2m-client-test-d731954d-dab3-4a2b-bdee-07f3ad1be885",
+     * 	  "iss": "stytch.com/project-test-3e71d0a1-1e3e-4ee2-9be0-d7c0900f02c2",
+     * 	  "aud": ["project-test-3e71d0a1-1e3e-4ee2-9be0-d7c0900f02c2"],
+     * 	  "scope": "read:users write:users",
+     * 	  "iat": 4102473300,
+     * 	  "nbf": 4102473300,
+     * 	  "exp": 4102476900
+     * 	}
      *
      * ```
      */
     public suspend fun token(data: TokenRequest): StytchResult<TokenResponse>
 
     /**
-     * Token retrieves an access token for the given M2M Client.
-     * Access tokens are JWTs signed with the project's JWKs, and are valid for one hour after issuance.
-     * M2M Access tokens contain a standard set of claims as well as any custom claims generated from templates.
-     * M2M Access tokens can be validated locally using the Authenticate Access Token method in the Stytch Backend SDKs,
+     * Token retrieves an access token for the given M2M Client. Access tokens are JWTs signed with
+     * the project's JWKs, and are valid for one hour after issuance. M2M Access tokens contain a
+     * standard set of claims as well as any custom claims generated from templates. M2M Access tokens
+     * can be validated locally using the Authenticate Access Token method in the Stytch Backend SDKs,
      * or with any library that supports JWT signature validation.
      *
      * Here is an example of a standard set of claims from a M2M Access Token:
      * ```
      *
-     *	{
-     *	  "sub": "m2m-client-test-d731954d-dab3-4a2b-bdee-07f3ad1be885",
-     *	  "iss": "stytch.com/project-test-3e71d0a1-1e3e-4ee2-9be0-d7c0900f02c2",
-     *	  "aud": ["project-test-3e71d0a1-1e3e-4ee2-9be0-d7c0900f02c2"],
-     *	  "scope": "read:users write:users",
-     *	  "iat": 4102473300,
-     *	  "nbf": 4102473300,
-     *	  "exp": 4102476900
-     *	}
+     * 	{
+     * 	  "sub": "m2m-client-test-d731954d-dab3-4a2b-bdee-07f3ad1be885",
+     * 	  "iss": "stytch.com/project-test-3e71d0a1-1e3e-4ee2-9be0-d7c0900f02c2",
+     * 	  "aud": ["project-test-3e71d0a1-1e3e-4ee2-9be0-d7c0900f02c2"],
+     * 	  "scope": "read:users write:users",
+     * 	  "iat": 4102473300,
+     * 	  "nbf": 4102473300,
+     * 	  "exp": 4102476900
+     * 	}
      *
      * ```
      */
@@ -91,24 +91,24 @@ public interface M2M {
     )
 
     /**
-     * Token retrieves an access token for the given M2M Client.
-     * Access tokens are JWTs signed with the project's JWKs, and are valid for one hour after issuance.
-     * M2M Access tokens contain a standard set of claims as well as any custom claims generated from templates.
-     * M2M Access tokens can be validated locally using the Authenticate Access Token method in the Stytch Backend SDKs,
+     * Token retrieves an access token for the given M2M Client. Access tokens are JWTs signed with
+     * the project's JWKs, and are valid for one hour after issuance. M2M Access tokens contain a
+     * standard set of claims as well as any custom claims generated from templates. M2M Access tokens
+     * can be validated locally using the Authenticate Access Token method in the Stytch Backend SDKs,
      * or with any library that supports JWT signature validation.
      *
      * Here is an example of a standard set of claims from a M2M Access Token:
      * ```
      *
-     *	{
-     *	  "sub": "m2m-client-test-d731954d-dab3-4a2b-bdee-07f3ad1be885",
-     *	  "iss": "stytch.com/project-test-3e71d0a1-1e3e-4ee2-9be0-d7c0900f02c2",
-     *	  "aud": ["project-test-3e71d0a1-1e3e-4ee2-9be0-d7c0900f02c2"],
-     *	  "scope": "read:users write:users",
-     *	  "iat": 4102473300,
-     *	  "nbf": 4102473300,
-     *	  "exp": 4102476900
-     *	}
+     * 	{
+     * 	  "sub": "m2m-client-test-d731954d-dab3-4a2b-bdee-07f3ad1be885",
+     * 	  "iss": "stytch.com/project-test-3e71d0a1-1e3e-4ee2-9be0-d7c0900f02c2",
+     * 	  "aud": ["project-test-3e71d0a1-1e3e-4ee2-9be0-d7c0900f02c2"],
+     * 	  "scope": "read:users write:users",
+     * 	  "iat": 4102473300,
+     * 	  "nbf": 4102473300,
+     * 	  "exp": 4102476900
+     * 	}
      *
      * ```
      */
@@ -124,16 +124,18 @@ public interface M2M {
     // ADDIMPORT: import com.stytch.java.common.JWTException
 
     /**
-     * AuthenticateToken validates an access token issued by Stytch from the Token endpoint.
-     * M2M access tokens are JWTs signed with the project's JWKs, and can be validated locally using any Stytch client library.
-     * You may pass in an optional set of scopes that the JWT must contain in order to enforce permissions.
+     * AuthenticateToken validates an access token issued by Stytch from the Token endpoint. M2M
+     * access tokens are JWTs signed with the project's JWKs, and can be validated locally using any
+     * Stytch client library. You may pass in an optional set of scopes that the JWT must contain in
+     * order to enforce permissions.
      */
     public suspend fun authenticateToken(data: AuthenticateTokenRequest): StytchResult<AuthenticateTokenResponse>
 
     /**
-     * AuthenticateToken validates an access token issued by Stytch from the Token endpoint.
-     * M2M access tokens are JWTs signed with the project's JWKs, and can be validated locally using any Stytch client library.
-     * You may pass in an optional set of scopes that the JWT must contain in order to enforce permissions.
+     * AuthenticateToken validates an access token issued by Stytch from the Token endpoint. M2M
+     * access tokens are JWTs signed with the project's JWKs, and can be validated locally using any
+     * Stytch client library. You may pass in an optional set of scopes that the JWT must contain in
+     * order to enforce permissions.
      */
     public suspend fun authenticateToken(
         data: AuthenticateTokenRequest,
@@ -141,9 +143,10 @@ public interface M2M {
     )
 
     /**
-     * AuthenticateToken validates an access token issued by Stytch from the Token endpoint.
-     * M2M access tokens are JWTs signed with the project's JWKs, and can be validated locally using any Stytch client library.
-     * You may pass in an optional set of scopes that the JWT must contain in order to enforce permissions.
+     * AuthenticateToken validates an access token issued by Stytch from the Token endpoint. M2M
+     * access tokens are JWTs signed with the project's JWKs, and can be validated locally using any
+     * Stytch client library. You may pass in an optional set of scopes that the JWT must contain in
+     * order to enforce permissions.
      */
     public suspend fun authenticateTokenCompletable(
         data: AuthenticateTokenRequest,
@@ -185,15 +188,11 @@ internal class M2MImpl(
         data: TokenRequest,
         callback: (StytchResult<TokenResponse>) -> Unit,
     ) {
-        coroutineScope.launch {
-            callback(token(data))
-        }
+        coroutineScope.launch { callback(token(data)) }
     }
 
     override fun tokenCompletable(data: TokenRequest): CompletableFuture<StytchResult<TokenResponse>> {
-        return coroutineScope.async {
-            token(data)
-        }.asCompletableFuture()
+        return coroutineScope.async { token(data) }.asCompletableFuture()
     }
     // ENDMANUAL(token_impl)
 
@@ -215,13 +214,7 @@ internal class M2MImpl(
                 val scopeString = jwtClaims.customClaims["scope"] as? String
                 val scopes = scopeString?.split(" ") ?: emptyList()
                 if (!data.requiredScopes.isNullOrEmpty()) {
-                    val missingScopes =
-                        data.requiredScopes.filter {
-                            !scopes.contains(it)
-                        }
-                    if (missingScopes.isNotEmpty()) {
-                        throw JWTException.JwtMissingScopes(missingScopes)
-                    }
+                    performAuthorizationCheck(scopes, data.requiredScopes)
                 }
                 StytchResult.Success(
                     AuthenticateTokenResponse(
@@ -232,7 +225,9 @@ internal class M2MImpl(
                 )
             } catch (e: JWTException.JwtTooOld) {
                 StytchResult.Error(StytchException.Critical(e))
-            } catch (e: JWTException.JwtMissingScopes) {
+            } catch (e: JWTException.JwtMissingAction) {
+                StytchResult.Error(StytchException.Critical(e))
+            } catch (e: JWTException.JwtMissingScope) {
                 StytchResult.Error(StytchException.Critical(e))
             } catch (e: Exception) {
                 StytchResult.Error(StytchException.Critical(JWTException.JwtError(e)))
@@ -243,17 +238,50 @@ internal class M2MImpl(
         data: AuthenticateTokenRequest,
         callback: (StytchResult<AuthenticateTokenResponse>) -> Unit,
     ) {
-        coroutineScope.launch {
-            callback(authenticateToken(data))
-        }
+        coroutineScope.launch { callback(authenticateToken(data)) }
     }
 
     override suspend fun authenticateTokenCompletable(
         data: AuthenticateTokenRequest,
     ): CompletableFuture<StytchResult<AuthenticateTokenResponse>> {
-        return coroutineScope.async {
-            authenticateToken(data)
-        }.asCompletableFuture()
+        return coroutineScope.async { authenticateToken(data) }.asCompletableFuture()
+    }
+
+    companion object {
+        @JvmStatic
+        fun performAuthorizationCheck(
+            hasScopes: List<String>,
+            requiredScopes: List<String>,
+        ) {
+            val clientScopes: MutableMap<String, MutableSet<String>> = mutableMapOf()
+            for (scope in hasScopes) {
+                var action = scope
+                var resource = "*"
+                if (":" in scope) {
+                    val (splitAction, splitResource) = scope.split(":")
+                    action = splitAction
+                    resource = splitResource
+                }
+                clientScopes.computeIfAbsent(action) { mutableSetOf() }.add(resource)
+            }
+
+            for (requiredScope in requiredScopes) {
+                var requiredAction = requiredScope
+                var requiredResource = "*"
+                if (":" in requiredScope) {
+                    val (splitAction, splitResource) = requiredScope.split(":")
+                    requiredAction = splitAction
+                    requiredResource = splitResource
+                }
+                val resources =
+                    clientScopes[requiredAction] ?: throw JWTException.JwtMissingAction(requiredAction)
+
+                // The client can either have a wildcard resource or the specific resource
+                if ("*" !in resources && requiredResource !in resources) {
+                    throw JWTException.JwtMissingScope(requiredScope)
+                }
+            }
+        }
     }
     // ENDMANUAL(authenticateToken_impl)
 }

--- a/stytch/src/test/kotlin/com/stytch/java/common/M2MTest.kt
+++ b/stytch/src/test/kotlin/com/stytch/java/common/M2MTest.kt
@@ -1,0 +1,59 @@
+package com.stytch.java.common
+
+import com.stytch.java.consumer.api.m2m.M2MImpl
+import org.junit.Test
+import org.junit.Assert.assertThrows
+
+class M2MTest {
+    @Test
+    fun `test basic`() {
+        val has = listOf("read:users", "write:users")
+        val needs = listOf("read:users")
+
+        // Assertion is just that no exception is raised
+        M2MImpl.performAuthorizationCheck(has, needs)
+    }
+
+    @Test
+    fun `test multiple required scopes`() {
+        val has = listOf("read:users", "write:users", "read:books")
+        val needs = listOf("read:users", "read:books")
+
+        // Assertion is just that no exception is raised
+        M2MImpl.performAuthorizationCheck(has, needs)
+    }
+
+    @Test
+    fun `test simple scopes`() {
+        val has = listOf("read_users", "write_users")
+        val needs = listOf("read_users")
+
+        // Assertion is just that no exception is raised
+        M2MImpl.performAuthorizationCheck(has, needs)
+    }
+
+    @Test
+    fun `test wildcard resource`() {
+        val has = listOf("read:*", "write:*")
+        val needs = listOf("read:users")
+
+        // Assertion is just that no exception is raised
+        M2MImpl.performAuthorizationCheck(has, needs)
+    }
+
+    @Test
+    fun `test missing required scope`() {
+        val has = listOf("read:users")
+        val needs = listOf("write:users")
+
+        assertThrows(JWTException::class.java) { M2MImpl.performAuthorizationCheck(has, needs) }
+    }
+
+    @Test
+    fun `test missing required scope with wildcard`() {
+        val has = listOf("read:users", "write:*")
+        val needs = listOf("delete:books")
+
+        assertThrows(JWTException::class.java) { M2MImpl.performAuthorizationCheck(has, needs) }
+    }
+}

--- a/stytch/src/test/kotlin/com/stytch/java/common/M2MTest.kt
+++ b/stytch/src/test/kotlin/com/stytch/java/common/M2MTest.kt
@@ -5,69 +5,69 @@ import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class M2MTest {
-  @Test
-  fun `test basic`() {
-    val has = listOf("read:users", "write:users")
-    val needs = listOf("read:users")
+    @Test
+    fun `test basic`() {
+        val has = listOf("read:users", "write:users")
+        val needs = listOf("read:users")
 
-    // Assertion is just that no exception is raised
-    M2MImpl.performAuthorizationCheck(has, needs)
-  }
+        // Assertion is just that no exception is raised
+        M2MImpl.performAuthorizationCheck(has, needs)
+    }
 
-  @Test
-  fun `test multiple required scopes`() {
-    val has = listOf("read:users", "write:users", "read:books")
-    val needs = listOf("read:users", "read:books")
+    @Test
+    fun `test multiple required scopes`() {
+        val has = listOf("read:users", "write:users", "read:books")
+        val needs = listOf("read:users", "read:books")
 
-    // Assertion is just that no exception is raised
-    M2MImpl.performAuthorizationCheck(has, needs)
-  }
+        // Assertion is just that no exception is raised
+        M2MImpl.performAuthorizationCheck(has, needs)
+    }
 
-  @Test
-  fun `test simple scopes`() {
-    val has = listOf("read_users", "write_users")
-    val needs = listOf("read_users")
+    @Test
+    fun `test simple scopes`() {
+        val has = listOf("read_users", "write_users")
+        val needs = listOf("read_users")
 
-    // Assertion is just that no exception is raised
-    M2MImpl.performAuthorizationCheck(has, needs)
-  }
+        // Assertion is just that no exception is raised
+        M2MImpl.performAuthorizationCheck(has, needs)
+    }
 
-  @Test
-  fun `test wildcard resource`() {
-    val has = listOf("read:*", "write:*")
-    val needs = listOf("read:users")
+    @Test
+    fun `test wildcard resource`() {
+        val has = listOf("read:*", "write:*")
+        val needs = listOf("read:users")
 
-    // Assertion is just that no exception is raised
-    M2MImpl.performAuthorizationCheck(has, needs)
-  }
+        // Assertion is just that no exception is raised
+        M2MImpl.performAuthorizationCheck(has, needs)
+    }
 
-  @Test
-  fun `test missing required scope`() {
-    val has = listOf("read:users")
-    val needs = listOf("write:users")
+    @Test
+    fun `test missing required scope`() {
+        val has = listOf("read:users")
+        val needs = listOf("write:users")
 
-    assertThrows(JWTException::class.java) { M2MImpl.performAuthorizationCheck(has, needs) }
-  }
+        assertThrows(JWTException::class.java) { M2MImpl.performAuthorizationCheck(has, needs) }
+    }
 
-  @Test
-  fun `test missing required scope with wildcard`() {
-    val has = listOf("read:users", "write:*")
-    val needs = listOf("delete:books")
+    @Test
+    fun `test missing required scope with wildcard`() {
+        val has = listOf("read:users", "write:*")
+        val needs = listOf("delete:books")
 
-    assertThrows(JWTException::class.java) { M2MImpl.performAuthorizationCheck(has, needs) }
-  }
+        assertThrows(JWTException::class.java) { M2MImpl.performAuthorizationCheck(has, needs) }
+    }
 
-  @Test
-  fun `has simple scope and wants specific scope`() {
-    val has = listOf("read")
-    val needs = listOf("read:users")
-    assertThrows(JWTException::class.java) { M2MImpl.performAuthorizationCheck(has, needs) }
-  }
+    @Test
+    fun `has simple scope and wants specific scope`() {
+        val has = listOf("read")
+        val needs = listOf("read:users")
+        assertThrows(JWTException::class.java) { M2MImpl.performAuthorizationCheck(has, needs) }
+    }
 
-  @Test
-  fun `has specific scope and wants simple scope`() {
-    val has = listOf("read:users")
-    val needs = listOf("read")
-    assertThrows(JWTException::class.java) { M2MImpl.performAuthorizationCheck(has, needs) }
-  }
+    @Test
+    fun `has specific scope and wants simple scope`() {
+        val has = listOf("read:users")
+        val needs = listOf("read")
+        assertThrows(JWTException::class.java) { M2MImpl.performAuthorizationCheck(has, needs) }
+    }
 }

--- a/stytch/src/test/kotlin/com/stytch/java/common/M2MTest.kt
+++ b/stytch/src/test/kotlin/com/stytch/java/common/M2MTest.kt
@@ -1,59 +1,73 @@
 package com.stytch.java.common
 
 import com.stytch.java.consumer.api.m2m.M2MImpl
-import org.junit.Test
 import org.junit.Assert.assertThrows
+import org.junit.Test
 
 class M2MTest {
-    @Test
-    fun `test basic`() {
-        val has = listOf("read:users", "write:users")
-        val needs = listOf("read:users")
+  @Test
+  fun `test basic`() {
+    val has = listOf("read:users", "write:users")
+    val needs = listOf("read:users")
 
-        // Assertion is just that no exception is raised
-        M2MImpl.performAuthorizationCheck(has, needs)
-    }
+    // Assertion is just that no exception is raised
+    M2MImpl.performAuthorizationCheck(has, needs)
+  }
 
-    @Test
-    fun `test multiple required scopes`() {
-        val has = listOf("read:users", "write:users", "read:books")
-        val needs = listOf("read:users", "read:books")
+  @Test
+  fun `test multiple required scopes`() {
+    val has = listOf("read:users", "write:users", "read:books")
+    val needs = listOf("read:users", "read:books")
 
-        // Assertion is just that no exception is raised
-        M2MImpl.performAuthorizationCheck(has, needs)
-    }
+    // Assertion is just that no exception is raised
+    M2MImpl.performAuthorizationCheck(has, needs)
+  }
 
-    @Test
-    fun `test simple scopes`() {
-        val has = listOf("read_users", "write_users")
-        val needs = listOf("read_users")
+  @Test
+  fun `test simple scopes`() {
+    val has = listOf("read_users", "write_users")
+    val needs = listOf("read_users")
 
-        // Assertion is just that no exception is raised
-        M2MImpl.performAuthorizationCheck(has, needs)
-    }
+    // Assertion is just that no exception is raised
+    M2MImpl.performAuthorizationCheck(has, needs)
+  }
 
-    @Test
-    fun `test wildcard resource`() {
-        val has = listOf("read:*", "write:*")
-        val needs = listOf("read:users")
+  @Test
+  fun `test wildcard resource`() {
+    val has = listOf("read:*", "write:*")
+    val needs = listOf("read:users")
 
-        // Assertion is just that no exception is raised
-        M2MImpl.performAuthorizationCheck(has, needs)
-    }
+    // Assertion is just that no exception is raised
+    M2MImpl.performAuthorizationCheck(has, needs)
+  }
 
-    @Test
-    fun `test missing required scope`() {
-        val has = listOf("read:users")
-        val needs = listOf("write:users")
+  @Test
+  fun `test missing required scope`() {
+    val has = listOf("read:users")
+    val needs = listOf("write:users")
 
-        assertThrows(JWTException::class.java) { M2MImpl.performAuthorizationCheck(has, needs) }
-    }
+    assertThrows(JWTException::class.java) { M2MImpl.performAuthorizationCheck(has, needs) }
+  }
 
-    @Test
-    fun `test missing required scope with wildcard`() {
-        val has = listOf("read:users", "write:*")
-        val needs = listOf("delete:books")
+  @Test
+  fun `test missing required scope with wildcard`() {
+    val has = listOf("read:users", "write:*")
+    val needs = listOf("delete:books")
 
-        assertThrows(JWTException::class.java) { M2MImpl.performAuthorizationCheck(has, needs) }
-    }
+    assertThrows(JWTException::class.java) { M2MImpl.performAuthorizationCheck(has, needs) }
+  }
+
+  @Test
+  fun `has simple scope and wants specific scope`() {
+    val has = listOf("read")
+    val needs = listOf("read:users")
+    assertThrows(JWTException::class.java) { M2MImpl.performAuthorizationCheck(has, needs) }
+  }
+
+  @Test
+  fun `has specific scope and wants simple scope`() {
+    val has = listOf("read:users")
+    val needs = listOf("read")
+    assertThrows(JWTException::class.java) { M2MImpl.performAuthorizationCheck(has, needs) }
+  }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,1 +1,1 @@
-version = "5.0.0"
+version = "5.1.0"


### PR DESCRIPTION
This PR adds support for wildcard scopes in M2M auth.
This means that an M2M client can have a scope like `read:*` and if given a required scope of `read:foo`, authentication will be allowed.

This does *not* affect "simple" scopes like `read` or `read_users` -- only scopes with a separating `:` are supported.

Furthermore, the assumption is that the scopes will be given as `action:resource`, though it is technically possible to assign in a different way like `users:read`, though in that case, a scope of `users:*` would **not** match a required scope of `read:users`. But as long as an application is consistent, this would be allowed.

Furthermore, a scope of just `*` does **not** get interpreted as an "omniscient" client -- instead, this is seen as the literal character `*` and gets matched similarly to `read_users` as mentioned above.