### PR TITLE
Add auto lint/test on PRs and fix failing test to expect correct exception

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+ktlint_standard_filename = disabled

--- a/.github/workflows/runOnGithub.yml
+++ b/.github/workflows/runOnGithub.yml
@@ -1,0 +1,23 @@
+name: runOnGitHub
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  gradle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 17
+
+      # Execute Gradle commands in GitHub Actions workflows
+      # => https://github.com/marketplace/actions/gradle-command
+      - uses: gradle/gradle-build-action@v2.4.2
+        with:
+          arguments: runOnGitHub
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,19 @@ plugins {
     kotlin("jvm") version libs.versions.kotlin
     kotlin("kapt") version libs.versions.kotlin
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+    id("org.jlleitschuh.gradle.ktlint") version "12.1.0"
+}
+
+subprojects {
+    apply(plugin = "org.jlleitschuh.gradle.ktlint")
+}
+
+allprojects {
+    ktlint {
+        version.set("1.2.1")
+        verbose.set(true)
+        outputToConsole.set(true)
+    }
 }
 
 buildscript {
@@ -45,4 +58,13 @@ task("printVersion") {
     doLast {
         println(version)
     }
+}
+
+task("runOnGitHub") {
+    group = "custom"
+    description = "\$ ./gradlew runOnGitHub # runs on GitHub Action"
+    dependsOn(
+        ":stytch:ktlintCheck",
+        ":stytch:test",
+    )
 }

--- a/stytch/src/test/kotlin/com/stytch/java/consumer/api/m2m/M2MTest.kt
+++ b/stytch/src/test/kotlin/com/stytch/java/consumer/api/m2m/M2MTest.kt
@@ -128,7 +128,7 @@ internal class M2MTest {
         }
 
     @Test
-    fun `authenticateToken returns JwtMissingScope exception when required scopes are missing`() =
+    fun `authenticateToken returns JwtMissingAction exception when required scopes are missing`() =
         runTest {
             val result =
                 m2m.authenticateToken(
@@ -139,7 +139,7 @@ internal class M2MTest {
                     ),
                 )
             require(result is StytchResult.Error)
-            assert(result.exception.reason is JWTException.JwtMissingScope)
+            assert(result.exception.reason is JWTException.JwtMissingAction)
         }
 
     @Test


### PR DESCRIPTION
* Adds ktlint and a workflow action to run lint and test on PR and push to main
* Fixes expected exception in M2M test
* The `ktlint_standard_filename = disabled` is because the file naming of the Attributes class is incorrect (plural in the class name and singular in the package name) and I'm guessing that's an oddity in the codegen that's not worth digging into (right now, anyway)