### PR TITLE
Change ChainId to string

### DIFF
--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/scimconnection/SCIMConnection.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/scimconnection/SCIMConnection.kt
@@ -227,7 +227,7 @@ public interface Connection {
     ): CompletableFuture<StytchResult<CreateResponse>>
 
     /**
-     * Get SCIM Connections.
+     * Get SCIM Connection.
      */
     public suspend fun get(
         data: GetRequest,
@@ -235,7 +235,7 @@ public interface Connection {
     ): StytchResult<GetResponse>
 
     /**
-     * Get SCIM Connections.
+     * Get SCIM Connection.
      */
     public fun get(
         data: GetRequest,
@@ -244,7 +244,7 @@ public interface Connection {
     )
 
     /**
-     * Get SCIM Connections.
+     * Get SCIM Connection.
      */
     public fun getCompletable(
         data: GetRequest,

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/organizations/Organizations.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/organizations/Organizations.kt
@@ -314,6 +314,13 @@ public data class MemberRoleSource
          *   SAML group implicit role assignments can be updated by passing in the `saml_group_implicit_role_assignments`
          *   argument to the [Update SAML connection](https://stytch.com/docs/b2b/api/update-saml-connection) endpoint.
          *
+         *     `scim_connection_group` – an implicit Role granted by the Member's SCIM connection and group. If the Member has
+         *   a SCIM Member registration with the given connection, and belongs to a specific group within the IdP, this role
+         * assignment will appear in the list.
+         *
+         *   SCIM group implicit role assignments can be updated by passing in the `scim_group_implicit_role_assignments`
+         *   argument to the [Update SCIM connection](https://stytch.com/docs/b2b/api/update-scim-connection) endpoint.
+         *
          */
         @Json(name = "type")
         val type: String,
@@ -328,6 +335,9 @@ public data class MemberRoleSource
          *   `sso_connection` – will contain the `connection_id` of the SAML connection that granted the assignment.
          *
          *   `sso_connection_group` – will contain the `connection_id` of the SAML connection and the name of the `group`
+         *   that granted the assignment.
+         *
+         *   `scim_connection_group` – will contain the `connection_id` of the SAML connection and the `group_id`
          *   that granted the assignment.
          *
          */

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/scim/SCIM.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/scim/SCIM.kt
@@ -73,6 +73,16 @@ public data class Group
     )
 
 @JsonClass(generateAdapter = true)
+public data class IMs
+    @JvmOverloads
+    constructor(
+        @Json(name = "value")
+        val value: String,
+        @Json(name = "type")
+        val type: String,
+    )
+
+@JsonClass(generateAdapter = true)
 public data class Manager
     @JvmOverloads
     constructor(
@@ -150,6 +160,8 @@ public data class SCIMAttributes
         val phoneNumbers: List<PhoneNumber>,
         @Json(name = "addresses")
         val addresses: List<Address>,
+        @Json(name = "ims")
+        val ims: List<IMs>,
         @Json(name = "name")
         val name: Name? = null,
         @Json(name = "enterprise_extension")
@@ -272,6 +284,9 @@ public data class SCIMGroupImplicitRoleAssignments
          */
         @Json(name = "role_id")
         val roleId: String,
+        /**
+         * The ID of the group.
+         */
         @Json(name = "group_id")
         val groupId: String,
         @Json(name = "group_name")

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/scimconnection/SCIMConnection.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/scimconnection/SCIMConnection.kt
@@ -579,7 +579,7 @@ public data class UpdateRequest
         @Json(name = "identity_provider")
         val identityProvider: UpdateRequestIdentityProvider? = null,
         /**
-         * An array of SCIM group implicit role assignments. Each object in the array must contain a `group` and a `role_id`.
+         * An array of SCIM group implicit role assignments. Each object in the array must contain a `group_id` and a `role_id`.
          */
         @Json(name = "scim_group_implicit_role_assignments")
         val scimGroupImplicitRoleAssignments: List<SCIMGroupImplicitRoleAssignments>? = emptyList(),

--- a/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
@@ -1,3 +1,3 @@
 package com.stytch.java.common
 
-internal const val VERSION = "5.3.0"
+internal const val VERSION = "5.4.0"

--- a/stytch/src/main/kotlin/com/stytch/java/consumer/models/cryptowallets/CryptoWallets.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/consumer/models/cryptowallets/CryptoWallets.kt
@@ -34,12 +34,15 @@ public data class SIWEParams
         @Json(name = "resources")
         val resources: List<String>,
         /**
-         * The EIP-155 Chain ID to which the session is bound. Defaults to 1.
+         * The EIP-155 Chain ID to which the session is bound. Defaults to 1. Must be the string representation of an integer
+         * between 1 and 9,223,372,036,854,775,771, inclusive.
          */
         @Json(name = "chain_id")
-        val chainId: Long? = null,
+        val chainId: String? = null,
         /**
-         * A human-readable ASCII assertion that the user will sign.
+         * A human-readable ASCII assertion that the user will sign. The statement may only include reserved, unreserved, or space
+         * characters according to RFC 3986 definitions, and must not contain other forms of whitespace such as newlines, tabs,
+         * and carriage returns.
          */
         @Json(name = "statement")
         val statement: String? = null,
@@ -56,7 +59,8 @@ public data class SIWEParams
         @Json(name = "not_before")
         val notBefore: Instant? = null,
         /**
-         * A system-specific identifier that may be used to uniquely refer to the sign-in request.
+         * A system-specific identifier that may be used to uniquely refer to the sign-in request. The `message_request_id` must
+         * be a valid pchar according to RFC 3986 definitions.
          */
         @Json(name = "message_request_id")
         val messageRequestId: String? = null,
@@ -272,7 +276,7 @@ public data class SIWEParamsResponse
          * The EIP-155 Chain ID to which the session is bound.
          */
         @Json(name = "chain_id")
-        val chainId: Int,
+        val chainId: String,
         /**
          *  A list of information or references to information the user wishes to have resolved as part of authentication. Every
          * resource must be an RFC 3986 URI.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,1 +1,1 @@
-version = "5.3.0"
+version = "5.4.0"


### PR DESCRIPTION
Changes the SIWE ChainID type to a string. Since SIWE isn't released yet, I'm marking this as a minor version bump.