### PR TITLE
Fix dokka dependency issues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,6 @@ allprojects {
 buildscript {
     dependencies {
         classpath(libs.dokka)
-        classpath(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.17.2")) // Force upgrade Dokka dependency
     }
 }
 

--- a/stytch/build.gradle.kts
+++ b/stytch/build.gradle.kts
@@ -30,12 +30,7 @@ kotlin {
     explicitApi()
 }
 
-val dokkaHtml by tasks.getting(org.jetbrains.dokka.gradle.DokkaTask::class) {
-    dependencies {
-        dokkaRuntime(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.17.2"))
-        dokkaPlugin(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.17.2"))
-    }
-}
+val dokkaHtml by tasks.getting(org.jetbrains.dokka.gradle.DokkaTask::class)
 val javadocJar: TaskProvider<Jar> by tasks.registering(Jar::class) {
     dependsOn(dokkaHtml)
     archiveClassifier.set("javadoc")

--- a/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
@@ -1,3 +1,3 @@
 package com.stytch.java.common
 
-internal const val VERSION = "5.4.0"
+internal const val VERSION = "5.4.1"

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,1 +1,1 @@
-version = "5.4.0"
+version = "5.4.1"


### PR DESCRIPTION
The previous maven publish failed due to a `dokka` dependency issue. This PR attempts to fix that by deleting references to jackson 2.17.2. I marked this as a patch so that the github action would pick it up as a release.