### PR TITLE
Publish 5.4.0

### DIFF
--- a/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
@@ -1,3 +1,3 @@
 package com.stytch.java.common
 
-internal const val VERSION = "5.4.1"
+internal const val VERSION = "5.4.0"

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,1 +1,1 @@
-version = "5.4.1"
+version = "5.4.0"


### PR DESCRIPTION
Now that we've made a couple of fixes that broke publishing, we need to change the version to get the Github action to run. Since 5.4.0 and 5.4.1 were not actually published, it should be safe to release 5.4.0 here. 