### PR TITLE
SDK-1521 Rerun codegen, making StytchClient instantiable, bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Check out our Java example app [here](https://github.com/stytchauth/stytch-java-
 ## Install
 
 ```
-implementation("com.stytch.java:sdk:1.1.0")
+implementation("com.stytch.java:sdk:6.0.0")
 ```
 
 ## Usage
@@ -51,7 +51,7 @@ Create an API client:
 Kotlin:
 ```kotlin
 import com.stytch.java.consumer.StytchClient
-StytchClient.configure(
+val client = StytchClient(
     projectId = "project-live-c60c0abe-c25a-4472-a9ed-320c6667d317",
     secret = "secret-live-80JASucyk7z_G8Z-7dVwZVGXL5NT_qGAQ2I="
 )
@@ -60,21 +60,21 @@ Java:
 
 ```java
 import com.stytch.java.consumer.StytchClient;
-StytchClient.configure(
-        "project-live-c60c0abe-c25a-4472-a9ed-320c6667d317",
-        "secret-live-80JASucyk7z_G8Z-7dVwZVGXL5NT_qGAQ2I="
-        );
+StytchClient client = new StytchClient(
+    "project-live-c60c0abe-c25a-4472-a9ed-320c6667d317",
+    "secret-live-80JASucyk7z_G8Z-7dVwZVGXL5NT_qGAQ2I="
+);
 ```
 
 Send a magic link by email:
 
 Kotlin:
 ```kotlin
-when (val result = StytchClient.magicLinks.email.loginOrCreate(
+when (val result = client.magicLinks.email.loginOrCreate(
     LoginOrCreateRequest(
         email = "email@address.com",
-        loginMagicLinkURL = "https://example.com/authenticate",
-        signupMagicLinkURL = "https://example.com/authenticate",
+        loginMagicLinkURL = "https://example.com/login",
+        signupMagicLinkURL = "https://example.com/signup",
     ),
 )) {
     is StytchResult.Success -> println(result.value)
@@ -85,23 +85,15 @@ Java:
 ```java
 LoginOrCreateRequest request = new LoginOrCreateRequest(
     "email@address.com",
-    "https://example.com/authenticate",
-    "https://example.com/authenticate",
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null
+    "https://example.com/signup",
+    "https://example.com/login"
 );
-StytchResult<LoginOrCreateResponse> response = StytchClient.magicLinks.getEmail().loginOrCreateCompletable(request).get();
+StytchResult<LoginOrCreateResponse> response = client.magicLinks.getEmail().loginOrCreateCompletable(request).get();
 if (response instanceof StytchResult.Error) {
     var exception = ((StytchResult.Error) response).getException();
     System.out.println(exception.getReason());
 } else {
-    System.out.println(((StytchResult.Success<?>) response).getValue());
+    System.out.println(((StytchResult.Success<LoginOrCreateResponse>) response).getValue());
 }
 ```
 
@@ -109,7 +101,7 @@ Authenticate the token from the magic link:
 
 Kotlin:
 ```kotlin
-when (val result = StytchClient.magicLinks.authenticate(
+when (val result = client.magicLinks.authenticate(
     AuthenticateRequest(token = "DOYoip3rvIMMW5lgItikFK-Ak1CfMsgjuiCyI7uuU94=")
 )) {
     is StytchResult.Success -> println(result.value)
@@ -119,12 +111,12 @@ when (val result = StytchClient.magicLinks.authenticate(
 Java:
 ```java
 AuthenticateRequest request = new AuthenticateRequest("DOYoip3rvIMMW5lgItikFK-Ak1CfMsgjuiCyI7uuU94=");
-StytchResult<AuthenticateResponse> response = StytchClient.magicLinks.authenticateCompletable(request).get();
+StytchResult<AuthenticateResponse> response = client.magicLinks.authenticateCompletable(request).get();
 if (response instanceof StytchResult.Error) {
     var exception = ((StytchResult.Error) response).getException();
     System.out.println(exception.getReason());
 } else {
-    System.out.println(((StytchResult.Success<?>) response).getValue());
+    System.out.println(((StytchResult.Success<AuthenticateResponse>) response).getValue());
 }
 ```
 
@@ -136,7 +128,7 @@ Kotlin:
 ```kotlin
 import com.stytch.java.b2b.StytchB2BClient
 ...
-StytchB2BClient.configure(
+val client  = StytchB2BClient(
     projectId = "project-live-c60c0abe-c25a-4472-a9ed-320c6667d317",
     secret = "secret-live-80JASucyk7z_G8Z-7dVwZVGXL5NT_qGAQ2I="
 )
@@ -146,17 +138,17 @@ Java:
 ```java
 import com.stytch.java.b2b.StytchB2BClient;
 ...
-        StytchB2BClient.configure(
-        "project-live-c60c0abe-c25a-4472-a9ed-320c6667d317",
-        "secret-live-80JASucyk7z_G8Z-7dVwZVGXL5NT_qGAQ2I="
-        );
+StytchB2BClient client = new StytchB2BClient(
+    "project-live-c60c0abe-c25a-4472-a9ed-320c6667d317",
+    "secret-live-80JASucyk7z_G8Z-7dVwZVGXL5NT_qGAQ2I="
+);
 ```
 
 Create an organization
 
 Kotlin:
 ```kotlin
-when (val result = StytchB2BClient.organizations.create(CreateRequest(
+when (val result = client.organizations.create(CreateRequest(
     organizationName = "Acme Co",
     organizationSlug = "acme-co",
     emailAllowedDomains = listOf("acme.co"),
@@ -172,17 +164,14 @@ emailAllowedDomains.add("acme.co");
 CreateRequest request = new CreateRequest(
         "Acme Co",
         "acme-co",
-        null,
-        null,
-        null,
         emailAllowedDomains
 );
-StytchResult<CreateResponse> response = StytchB2BClient.organizations.createCompletable(request).get();
+StytchResult<CreateResponse> response = client.organizations.createCompletable(request).get();
 if (response instanceof StytchResult.Error) {
     var exception = ((StytchResult.Error) response).getException();
     System.out.println(exception.getReason());
 } else {
-    System.out.println(((StytchResult.Success<?>) response).getValue());
+    System.out.println(((StytchResult.Success<CreateResponse>) response).getValue());
 }
 ```
 
@@ -190,7 +179,7 @@ Log the first user into the organization
 
 Kotlin:
 ```kotlin
-when (val result = StytchB2BClient.magicLinks.email.loginOrSignup(LoginOrSignupRequest(
+when (val result = client.magicLinks.email.loginOrSignup(LoginOrSignupRequest(
     organizationId = "organization-id-from-create-response-...",
     emailAddress = "admin@acme.co",
     loginRedirectURL = "https://example.com/authenticate",
@@ -208,12 +197,12 @@ LoginOrSignupRequest request = new LoginOrSignupRequest(
     "https://example.com/authenticate",
     "https://example.com/authenticate"
 );
-StytchResult<LoginOrSignupResponse> response = StytchB2BClient.magicLinks.getEmail().loginOrSignup(request).get();
+StytchResult<LoginOrSignupResponse> response = client.magicLinks.getEmail().loginOrSignup(request).get();
 if (response instanceof StytchResult.Error) {
     var exception = ((StytchResult.Error) response).getException();
     System.out.println(exception.getReason());
 } else {
-    System.out.println(((StytchResult.Success<?>) response).getValue());
+    System.out.println(((StytchResult.Success<LoginOrSignupResponse>) response).getValue());
 }
 ```
 

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/StytchB2BClient.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/StytchB2BClient.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.SupervisorJob
 import org.jose4j.jwk.HttpsJwks
 
 public class StytchB2BClient(projectId: String, secret: String) {
+    private val coroutineScope = CoroutineScope(SupervisorJob())
     private val baseUrl = getBaseUrl(projectId)
     private val httpClient: HttpClient =
         HttpClient(
@@ -58,8 +59,6 @@ public class StytchB2BClient(projectId: String, secret: String) {
             type = "JWT",
         )
     private val policyCache: PolicyCache = PolicyCache(RBACImpl(httpClient, coroutineScope))
-
-    private val coroutineScope = CoroutineScope(SupervisorJob())
 
     @JvmField
     public val discovery: Discovery = DiscoveryImpl(httpClient, coroutineScope)

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/StytchB2BClient.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/StytchB2BClient.kt
@@ -42,91 +42,66 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import org.jose4j.jwk.HttpsJwks
 
-public object StytchB2BClient {
-    private lateinit var httpClient: HttpClient
-    private lateinit var httpsJwks: HttpsJwks
-    private lateinit var jwtOptions: JwtOptions
-    private lateinit var policyCache: PolicyCache
+public class StytchB2BClient(projectId: String, secret: String) {
+    private val baseUrl = getBaseUrl(projectId)
+    private val httpClient: HttpClient =
+        HttpClient(
+            baseUrl = baseUrl,
+            projectId = projectId,
+            secret = secret,
+        )
+    private val httpsJwks = HttpsJwks("$baseUrl/v1/b2b/sessions/jwks/$projectId")
+    private val jwtOptions: JwtOptions =
+        JwtOptions(
+            audience = projectId,
+            issuer = "stytch.com/$projectId",
+            type = "JWT",
+        )
+    private val policyCache: PolicyCache = PolicyCache(RBACImpl(httpClient, coroutineScope))
 
-    @JvmStatic
-    public lateinit var discovery: Discovery
+    private val coroutineScope = CoroutineScope(SupervisorJob())
 
-    @JvmStatic
-    public lateinit var m2m: M2M
+    @JvmField
+    public val discovery: Discovery = DiscoveryImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public lateinit var magicLinks: MagicLinks
+    @JvmField
+    public val m2m: M2M = M2MImpl(httpClient, coroutineScope, httpsJwks, jwtOptions)
 
-    @JvmStatic
-    public lateinit var oauth: OAuth
+    @JvmField
+    public val magicLinks: MagicLinks = MagicLinksImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public lateinit var otps: OTPs
+    @JvmField
+    public val oauth: OAuth = OAuthImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public lateinit var organizations: Organizations
+    @JvmField
+    public val otps: OTPs = OTPsImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public lateinit var passwords: Passwords
+    @JvmField
+    public val organizations: Organizations = OrganizationsImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public lateinit var project: Project
+    @JvmField
+    public val passwords: Passwords = PasswordsImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public lateinit var rbac: RBAC
+    @JvmField
+    public val project: Project = ProjectImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public lateinit var recoveryCodes: RecoveryCodes
+    @JvmField
+    public val rbac: RBAC = RBACImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public lateinit var scim: SCIM
+    @JvmField
+    public val recoveryCodes: RecoveryCodes = RecoveryCodesImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public lateinit var sso: SSO
+    @JvmField
+    public val scim: SCIM = SCIMImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public lateinit var sessions: Sessions
+    @JvmField
+    public val sso: SSO = SSOImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public lateinit var totps: TOTPs
+    @JvmField
+    public val sessions: Sessions = SessionsImpl(httpClient, coroutineScope, httpsJwks, jwtOptions, policyCache)
 
-    @JvmStatic
-    public fun configure(
-        projectId: String,
-        secret: String,
-    ) {
-        val baseUrl = getBaseUrl(projectId)
-        httpClient =
-            HttpClient(
-                baseUrl = baseUrl,
-                projectId = projectId,
-                secret = secret,
-            )
-        jwtOptions =
-            JwtOptions(
-                audience = projectId,
-                issuer = "stytch.com/$projectId",
-                type = "JWT",
-            )
-        val coroutineScope = CoroutineScope(SupervisorJob())
-        httpsJwks = HttpsJwks("$baseUrl/v1/b2b/sessions/jwks/$projectId")
-        policyCache = PolicyCache(RBACImpl(httpClient, coroutineScope))
-
-        discovery = DiscoveryImpl(httpClient, coroutineScope)
-        m2m = M2MImpl(httpClient, coroutineScope, httpsJwks, jwtOptions)
-        magicLinks = MagicLinksImpl(httpClient, coroutineScope)
-        oauth = OAuthImpl(httpClient, coroutineScope)
-        otps = OTPsImpl(httpClient, coroutineScope)
-        organizations = OrganizationsImpl(httpClient, coroutineScope)
-        passwords = PasswordsImpl(httpClient, coroutineScope)
-        project = ProjectImpl(httpClient, coroutineScope)
-        rbac = RBACImpl(httpClient, coroutineScope)
-        recoveryCodes = RecoveryCodesImpl(httpClient, coroutineScope)
-        scim = SCIMImpl(httpClient, coroutineScope)
-        sso = SSOImpl(httpClient, coroutineScope)
-        sessions = SessionsImpl(httpClient, coroutineScope, httpsJwks, jwtOptions, policyCache)
-        totps = TOTPsImpl(httpClient, coroutineScope)
-    }
+    @JvmField
+    public val totps: TOTPs = TOTPsImpl(httpClient, coroutineScope)
 
     /**
      * Resolve the base URL for the Stytch API environment.

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/discoveryintermediatesessions/DiscoveryIntermediateSessions.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/discoveryintermediatesessions/DiscoveryIntermediateSessions.kt
@@ -28,8 +28,7 @@ public interface IntermediateSessions {
      *
      * This endpoint can be used to accept invites and create new members via domain matching.
      *
-     * If the Member is required to complete MFA to log in to the Organization, the returned value of `member_authenticated`
-     * will be `false`.
+     * If the is required to complete MFA to log in to the, the returned value of `member_authenticated` will be `false`.
      * The `intermediate_session_token` will not be consumed and instead will be returned in the response.
      * The `intermediate_session_token` can be passed into the
      * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms) to complete the MFA step and
@@ -39,6 +38,13 @@ public interface IntermediateSessions {
      * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to join
      * a different Organization or create a new one.
      * The `session_duration_minutes` and `session_custom_claims` parameters will be ignored.
+     *
+     * If the Member is logging in via an OAuth provider that does not fully verify the email, the returned value of
+     * `member_authenticated` will be `false`.
+     * The `intermediate_session_token` will not be consumed and instead will be returned in the response.
+     * The `primary_required` field details the authentication flow the Member must perform in order to
+     * [complete a step-up authentication](https://stytch.com/docs/b2b/guides/oauth/auth-flows) into the organization. The
+     * `intermediate_session_token` must be passed into that authentication flow.
      */
     public suspend fun exchange(data: ExchangeRequest): StytchResult<ExchangeResponse>
 
@@ -49,8 +55,7 @@ public interface IntermediateSessions {
      *
      * This endpoint can be used to accept invites and create new members via domain matching.
      *
-     * If the Member is required to complete MFA to log in to the Organization, the returned value of `member_authenticated`
-     * will be `false`.
+     * If the is required to complete MFA to log in to the, the returned value of `member_authenticated` will be `false`.
      * The `intermediate_session_token` will not be consumed and instead will be returned in the response.
      * The `intermediate_session_token` can be passed into the
      * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms) to complete the MFA step and
@@ -60,6 +65,13 @@ public interface IntermediateSessions {
      * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to join
      * a different Organization or create a new one.
      * The `session_duration_minutes` and `session_custom_claims` parameters will be ignored.
+     *
+     * If the Member is logging in via an OAuth provider that does not fully verify the email, the returned value of
+     * `member_authenticated` will be `false`.
+     * The `intermediate_session_token` will not be consumed and instead will be returned in the response.
+     * The `primary_required` field details the authentication flow the Member must perform in order to
+     * [complete a step-up authentication](https://stytch.com/docs/b2b/guides/oauth/auth-flows) into the organization. The
+     * `intermediate_session_token` must be passed into that authentication flow.
      */
     public fun exchange(
         data: ExchangeRequest,
@@ -73,8 +85,7 @@ public interface IntermediateSessions {
      *
      * This endpoint can be used to accept invites and create new members via domain matching.
      *
-     * If the Member is required to complete MFA to log in to the Organization, the returned value of `member_authenticated`
-     * will be `false`.
+     * If the is required to complete MFA to log in to the, the returned value of `member_authenticated` will be `false`.
      * The `intermediate_session_token` will not be consumed and instead will be returned in the response.
      * The `intermediate_session_token` can be passed into the
      * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms) to complete the MFA step and
@@ -84,6 +95,13 @@ public interface IntermediateSessions {
      * [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to join
      * a different Organization or create a new one.
      * The `session_duration_minutes` and `session_custom_claims` parameters will be ignored.
+     *
+     * If the Member is logging in via an OAuth provider that does not fully verify the email, the returned value of
+     * `member_authenticated` will be `false`.
+     * The `intermediate_session_token` will not be consumed and instead will be returned in the response.
+     * The `primary_required` field details the authentication flow the Member must perform in order to
+     * [complete a step-up authentication](https://stytch.com/docs/b2b/guides/oauth/auth-flows) into the organization. The
+     * `intermediate_session_token` must be passed into that authentication flow.
      */
     public fun exchangeCompletable(data: ExchangeRequest): CompletableFuture<StytchResult<ExchangeResponse>>
 }

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/discoveryorganizations/DiscoveryOrganizations.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/discoveryorganizations/DiscoveryOrganizations.kt
@@ -24,8 +24,8 @@ import java.util.concurrent.CompletableFuture
 
 public interface Organizations {
     /**
-     * If an end user does not want to join any already-existing Organization, or has no possible Organizations to join, this
-     * endpoint can be used to create a new
+     * If an end user does not want to join any already-existing, or has no possible Organizations to join, this endpoint can
+     * be used to create a new
      * [Organization](https://stytch.com/docs/b2b/api/organization-object) and
      * [Member](https://stytch.com/docs/b2b/api/member-object).
      *
@@ -33,7 +33,7 @@ public interface Organizations {
      *
      * This endpoint will also create an initial Member Session for the newly created Member.
      *
-     * The Member created by this endpoint will automatically be granted the `stytch_admin` Role. See the
+     * The created by this endpoint will automatically be granted the `stytch_admin` Role. See the
      * [RBAC guide](https://stytch.com/docs/b2b/guides/rbac/stytch-default) for more details on this Role.
      *
      * If the new Organization is created with a `mfa_policy` of `REQUIRED_FOR_ALL`, the newly created Member will need to
@@ -51,8 +51,8 @@ public interface Organizations {
     public suspend fun create(data: CreateRequest): StytchResult<CreateResponse>
 
     /**
-     * If an end user does not want to join any already-existing Organization, or has no possible Organizations to join, this
-     * endpoint can be used to create a new
+     * If an end user does not want to join any already-existing, or has no possible Organizations to join, this endpoint can
+     * be used to create a new
      * [Organization](https://stytch.com/docs/b2b/api/organization-object) and
      * [Member](https://stytch.com/docs/b2b/api/member-object).
      *
@@ -60,7 +60,7 @@ public interface Organizations {
      *
      * This endpoint will also create an initial Member Session for the newly created Member.
      *
-     * The Member created by this endpoint will automatically be granted the `stytch_admin` Role. See the
+     * The created by this endpoint will automatically be granted the `stytch_admin` Role. See the
      * [RBAC guide](https://stytch.com/docs/b2b/guides/rbac/stytch-default) for more details on this Role.
      *
      * If the new Organization is created with a `mfa_policy` of `REQUIRED_FOR_ALL`, the newly created Member will need to
@@ -81,8 +81,8 @@ public interface Organizations {
     )
 
     /**
-     * If an end user does not want to join any already-existing Organization, or has no possible Organizations to join, this
-     * endpoint can be used to create a new
+     * If an end user does not want to join any already-existing, or has no possible Organizations to join, this endpoint can
+     * be used to create a new
      * [Organization](https://stytch.com/docs/b2b/api/organization-object) and
      * [Member](https://stytch.com/docs/b2b/api/member-object).
      *
@@ -90,7 +90,7 @@ public interface Organizations {
      *
      * This endpoint will also create an initial Member Session for the newly created Member.
      *
-     * The Member created by this endpoint will automatically be granted the `stytch_admin` Role. See the
+     * The created by this endpoint will automatically be granted the `stytch_admin` Role. See the
      * [RBAC guide](https://stytch.com/docs/b2b/guides/rbac/stytch-default) for more details on this Role.
      *
      * If the new Organization is created with a `mfa_policy` of `REQUIRED_FOR_ALL`, the newly created Member will need to

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/magiclinks/MagicLinks.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/magiclinks/MagicLinks.kt
@@ -30,13 +30,13 @@ public interface MagicLinks {
     public val discovery: Discovery
 
     /**
-     * Authenticate a Member with a Magic Link. This endpoint requires a Magic Link token that is not expired or previously
-     * used. If the Member’s status is `pending` or `invited`, they will be updated to `active`.
+     * Authenticate a with a Magic Link. This endpoint requires a Magic Link token that is not expired or previously used. If
+     * the Member’s status is `pending` or `invited`, they will be updated to `active`.
      * Provide the `session_duration_minutes` parameter to set the lifetime of the session. If the `session_duration_minutes`
      * parameter is not specified, a Stytch session will be created with a 60 minute duration.
      *
-     * If the Member is required to complete MFA to log in to the Organization, the returned value of `member_authenticated`
-     * will be `false`, and an `intermediate_session_token` will be returned.
+     * If the Member is required to complete MFA to log in to the, the returned value of `member_authenticated` will be
+     * `false`, and an `intermediate_session_token` will be returned.
      * The `intermediate_session_token` can be passed into the
      * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
      * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
@@ -53,13 +53,13 @@ public interface MagicLinks {
     public suspend fun authenticate(data: AuthenticateRequest): StytchResult<AuthenticateResponse>
 
     /**
-     * Authenticate a Member with a Magic Link. This endpoint requires a Magic Link token that is not expired or previously
-     * used. If the Member’s status is `pending` or `invited`, they will be updated to `active`.
+     * Authenticate a with a Magic Link. This endpoint requires a Magic Link token that is not expired or previously used. If
+     * the Member’s status is `pending` or `invited`, they will be updated to `active`.
      * Provide the `session_duration_minutes` parameter to set the lifetime of the session. If the `session_duration_minutes`
      * parameter is not specified, a Stytch session will be created with a 60 minute duration.
      *
-     * If the Member is required to complete MFA to log in to the Organization, the returned value of `member_authenticated`
-     * will be `false`, and an `intermediate_session_token` will be returned.
+     * If the Member is required to complete MFA to log in to the, the returned value of `member_authenticated` will be
+     * `false`, and an `intermediate_session_token` will be returned.
      * The `intermediate_session_token` can be passed into the
      * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
      * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
@@ -79,13 +79,13 @@ public interface MagicLinks {
     )
 
     /**
-     * Authenticate a Member with a Magic Link. This endpoint requires a Magic Link token that is not expired or previously
-     * used. If the Member’s status is `pending` or `invited`, they will be updated to `active`.
+     * Authenticate a with a Magic Link. This endpoint requires a Magic Link token that is not expired or previously used. If
+     * the Member’s status is `pending` or `invited`, they will be updated to `active`.
      * Provide the `session_duration_minutes` parameter to set the lifetime of the session. If the `session_duration_minutes`
      * parameter is not specified, a Stytch session will be created with a 60 minute duration.
      *
-     * If the Member is required to complete MFA to log in to the Organization, the returned value of `member_authenticated`
-     * will be `false`, and an `intermediate_session_token` will be returned.
+     * If the Member is required to complete MFA to log in to the, the returned value of `member_authenticated` will be
+     * `false`, and an `intermediate_session_token` will be returned.
      * The `intermediate_session_token` can be passed into the
      * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
      * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/magiclinksemail/MagicLinksEmail.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/magiclinksemail/MagicLinksEmail.kt
@@ -59,9 +59,9 @@ public interface Email {
     public fun loginOrSignupCompletable(data: LoginOrSignupRequest): CompletableFuture<StytchResult<LoginOrSignupResponse>>
 
     /**
-     * Send an invite email to a new Member to join an Organization. The Member will be created with an `invited` status until
-     * they successfully authenticate. Sending invites to `pending` Members will update their status to `invited`. Sending
-     * invites to already `active` Members will return an error.
+     * Send an invite email to a new to join an. The Member will be created with an `invited` status until they successfully
+     * authenticate. Sending invites to `pending` Members will update their status to `invited`. Sending invites to already
+     * `active` Members will return an error.
      *
      * The magic link invite will be valid for 1 week.
      */
@@ -71,9 +71,9 @@ public interface Email {
     ): StytchResult<InviteResponse>
 
     /**
-     * Send an invite email to a new Member to join an Organization. The Member will be created with an `invited` status until
-     * they successfully authenticate. Sending invites to `pending` Members will update their status to `invited`. Sending
-     * invites to already `active` Members will return an error.
+     * Send an invite email to a new to join an. The Member will be created with an `invited` status until they successfully
+     * authenticate. Sending invites to `pending` Members will update their status to `invited`. Sending invites to already
+     * `active` Members will return an error.
      *
      * The magic link invite will be valid for 1 week.
      */
@@ -84,9 +84,9 @@ public interface Email {
     )
 
     /**
-     * Send an invite email to a new Member to join an Organization. The Member will be created with an `invited` status until
-     * they successfully authenticate. Sending invites to `pending` Members will update their status to `invited`. Sending
-     * invites to already `active` Members will return an error.
+     * Send an invite email to a new to join an. The Member will be created with an `invited` status until they successfully
+     * authenticate. Sending invites to `pending` Members will update their status to `invited`. Sending invites to already
+     * `active` Members will return an error.
      *
      * The magic link invite will be valid for 1 week.
      */

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/oauth/OAuth.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/oauth/OAuth.kt
@@ -26,13 +26,12 @@ public interface OAuth {
     public val discovery: Discovery
 
     /**
-     * Authenticate a Member given a `token`. This endpoint verifies that the member completed the OAuth flow by verifying
-     * that the token is valid and hasn't expired.  Provide the `session_duration_minutes` parameter to set the lifetime of
-     * the session. If the `session_duration_minutes` parameter is not specified, a Stytch session will be created with a 60
-     * minute duration.
+     * Authenticate a given a `token`. This endpoint verifies that the member completed the flow by verifying that the token
+     * is valid and hasn't expired.  Provide the `session_duration_minutes` parameter to set the lifetime of the session. If
+     * the `session_duration_minutes` parameter is not specified, a Stytch session will be created with a 60 minute duration.
      *
-     * If the Member is required to complete MFA to log in to the Organization, the returned value of `member_authenticated`
-     * will be `false`, and an `intermediate_session_token` will be returned.
+     * If the Member is required to complete MFA to log in to the, the returned value of `member_authenticated` will be
+     * `false`, and an `intermediate_session_token` will be returned.
      * The `intermediate_session_token` can be passed into the
      * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms) to complete the MFA step and
      * acquire a full member session.
@@ -43,6 +42,12 @@ public interface OAuth {
      * The `session_duration_minutes` and `session_custom_claims` parameters will be ignored.
      *
      * If a valid `session_token` or `session_jwt` is passed in, the Member will not be required to complete an MFA step.
+     *
+     * If the Member is logging in via an OAuth provider that does not fully verify the email, the returned value of
+     * `member_authenticated` will be `false`, and an `intermediate_session_token` will be returned.
+     * The `primary_required` field details the authentication flow the Member must perform in order to
+     * [complete a step-up authentication](https://stytch.com/docs/b2b/guides/oauth/auth-flows) into the organization. The
+     * `intermediate_session_token` must be passed into that authentication flow.
      *
      * We’re actively accepting requests for new OAuth providers! Please [email us](mailto:support@stytch.com) or
      * [post in our community](https://stytch.com/docs/b2b/resources) if you are looking for an OAuth provider that is not
@@ -51,13 +56,12 @@ public interface OAuth {
     public suspend fun authenticate(data: AuthenticateRequest): StytchResult<AuthenticateResponse>
 
     /**
-     * Authenticate a Member given a `token`. This endpoint verifies that the member completed the OAuth flow by verifying
-     * that the token is valid and hasn't expired.  Provide the `session_duration_minutes` parameter to set the lifetime of
-     * the session. If the `session_duration_minutes` parameter is not specified, a Stytch session will be created with a 60
-     * minute duration.
+     * Authenticate a given a `token`. This endpoint verifies that the member completed the flow by verifying that the token
+     * is valid and hasn't expired.  Provide the `session_duration_minutes` parameter to set the lifetime of the session. If
+     * the `session_duration_minutes` parameter is not specified, a Stytch session will be created with a 60 minute duration.
      *
-     * If the Member is required to complete MFA to log in to the Organization, the returned value of `member_authenticated`
-     * will be `false`, and an `intermediate_session_token` will be returned.
+     * If the Member is required to complete MFA to log in to the, the returned value of `member_authenticated` will be
+     * `false`, and an `intermediate_session_token` will be returned.
      * The `intermediate_session_token` can be passed into the
      * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms) to complete the MFA step and
      * acquire a full member session.
@@ -68,6 +72,12 @@ public interface OAuth {
      * The `session_duration_minutes` and `session_custom_claims` parameters will be ignored.
      *
      * If a valid `session_token` or `session_jwt` is passed in, the Member will not be required to complete an MFA step.
+     *
+     * If the Member is logging in via an OAuth provider that does not fully verify the email, the returned value of
+     * `member_authenticated` will be `false`, and an `intermediate_session_token` will be returned.
+     * The `primary_required` field details the authentication flow the Member must perform in order to
+     * [complete a step-up authentication](https://stytch.com/docs/b2b/guides/oauth/auth-flows) into the organization. The
+     * `intermediate_session_token` must be passed into that authentication flow.
      *
      * We’re actively accepting requests for new OAuth providers! Please [email us](mailto:support@stytch.com) or
      * [post in our community](https://stytch.com/docs/b2b/resources) if you are looking for an OAuth provider that is not
@@ -79,13 +89,12 @@ public interface OAuth {
     )
 
     /**
-     * Authenticate a Member given a `token`. This endpoint verifies that the member completed the OAuth flow by verifying
-     * that the token is valid and hasn't expired.  Provide the `session_duration_minutes` parameter to set the lifetime of
-     * the session. If the `session_duration_minutes` parameter is not specified, a Stytch session will be created with a 60
-     * minute duration.
+     * Authenticate a given a `token`. This endpoint verifies that the member completed the flow by verifying that the token
+     * is valid and hasn't expired.  Provide the `session_duration_minutes` parameter to set the lifetime of the session. If
+     * the `session_duration_minutes` parameter is not specified, a Stytch session will be created with a 60 minute duration.
      *
-     * If the Member is required to complete MFA to log in to the Organization, the returned value of `member_authenticated`
-     * will be `false`, and an `intermediate_session_token` will be returned.
+     * If the Member is required to complete MFA to log in to the, the returned value of `member_authenticated` will be
+     * `false`, and an `intermediate_session_token` will be returned.
      * The `intermediate_session_token` can be passed into the
      * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms) to complete the MFA step and
      * acquire a full member session.
@@ -96,6 +105,12 @@ public interface OAuth {
      * The `session_duration_minutes` and `session_custom_claims` parameters will be ignored.
      *
      * If a valid `session_token` or `session_jwt` is passed in, the Member will not be required to complete an MFA step.
+     *
+     * If the Member is logging in via an OAuth provider that does not fully verify the email, the returned value of
+     * `member_authenticated` will be `false`, and an `intermediate_session_token` will be returned.
+     * The `primary_required` field details the authentication flow the Member must perform in order to
+     * [complete a step-up authentication](https://stytch.com/docs/b2b/guides/oauth/auth-flows) into the organization. The
+     * `intermediate_session_token` must be passed into that authentication flow.
      *
      * We’re actively accepting requests for new OAuth providers! Please [email us](mailto:support@stytch.com) or
      * [post in our community](https://stytch.com/docs/b2b/resources) if you are looking for an OAuth provider that is not

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/oauthdiscovery/OAuthDiscovery.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/oauthdiscovery/OAuthDiscovery.kt
@@ -22,14 +22,14 @@ import java.util.concurrent.CompletableFuture
 
 public interface Discovery {
     /**
-     * Authenticates the Discovery OAuth token and exchanges it for an Intermediate Session Token. Intermediate Session Tokens
-     * can be used for various Discovery login flows and are valid for 10 minutes.
+     * Authenticates the Discovery token and exchanges it for an Intermediate Session Token. Intermediate Session Tokens can
+     * be used for various Discovery login flows and are valid for 10 minutes.
      */
     public suspend fun authenticate(data: AuthenticateRequest): StytchResult<AuthenticateResponse>
 
     /**
-     * Authenticates the Discovery OAuth token and exchanges it for an Intermediate Session Token. Intermediate Session Tokens
-     * can be used for various Discovery login flows and are valid for 10 minutes.
+     * Authenticates the Discovery token and exchanges it for an Intermediate Session Token. Intermediate Session Tokens can
+     * be used for various Discovery login flows and are valid for 10 minutes.
      */
     public fun authenticate(
         data: AuthenticateRequest,
@@ -37,8 +37,8 @@ public interface Discovery {
     )
 
     /**
-     * Authenticates the Discovery OAuth token and exchanges it for an Intermediate Session Token. Intermediate Session Tokens
-     * can be used for various Discovery login flows and are valid for 10 minutes.
+     * Authenticates the Discovery token and exchanges it for an Intermediate Session Token. Intermediate Session Tokens can
+     * be used for various Discovery login flows and are valid for 10 minutes.
      */
     public fun authenticateCompletable(data: AuthenticateRequest): CompletableFuture<StytchResult<AuthenticateResponse>>
 }

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/organizations/Organizations.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/organizations/Organizations.kt
@@ -40,7 +40,7 @@ public interface Organizations {
     public val members: Members
 
     /**
-     * Creates an Organization. An `organization_name` and a unique `organization_slug` are required.
+     * Creates an. An `organization_name` and a unique `organization_slug` are required.
      *
      * By default, `email_invites` and `sso_jit_provisioning` will be set to `ALL_ALLOWED`, and `mfa_policy` will be set to
      * `OPTIONAL` if no Organization authentication settings are explicitly defined in the request.
@@ -51,7 +51,7 @@ public interface Organizations {
     public suspend fun create(data: CreateRequest): StytchResult<CreateResponse>
 
     /**
-     * Creates an Organization. An `organization_name` and a unique `organization_slug` are required.
+     * Creates an. An `organization_name` and a unique `organization_slug` are required.
      *
      * By default, `email_invites` and `sso_jit_provisioning` will be set to `ALL_ALLOWED`, and `mfa_policy` will be set to
      * `OPTIONAL` if no Organization authentication settings are explicitly defined in the request.
@@ -65,7 +65,7 @@ public interface Organizations {
     )
 
     /**
-     * Creates an Organization. An `organization_name` and a unique `organization_slug` are required.
+     * Creates an. An `organization_name` and a unique `organization_slug` are required.
      *
      * By default, `email_invites` and `sso_jit_provisioning` will be set to `ALL_ALLOWED`, and `mfa_policy` will be set to
      * `OPTIONAL` if no Organization authentication settings are explicitly defined in the request.
@@ -76,12 +76,12 @@ public interface Organizations {
     public fun createCompletable(data: CreateRequest): CompletableFuture<StytchResult<CreateResponse>>
 
     /**
-     * Returns an Organization specified by `organization_id`.
+     * Returns an specified by `organization_id`.
      */
     public suspend fun get(data: GetRequest): StytchResult<GetResponse>
 
     /**
-     * Returns an Organization specified by `organization_id`.
+     * Returns an specified by `organization_id`.
      */
     public fun get(
         data: GetRequest,
@@ -89,13 +89,13 @@ public interface Organizations {
     )
 
     /**
-     * Returns an Organization specified by `organization_id`.
+     * Returns an specified by `organization_id`.
      */
     public fun getCompletable(data: GetRequest): CompletableFuture<StytchResult<GetResponse>>
 
     /**
-     * Updates an Organization specified by `organization_id`. An Organization must always have at least one auth setting set
-     * to either `RESTRICTED` or `ALL_ALLOWED` in order to provision new Members.
+     * Updates an specified by `organization_id`. An Organization must always have at least one auth setting set to either
+     * `RESTRICTED` or `ALL_ALLOWED` in order to provision new Members.
      *
      * *See the [Organization authentication settings](https://stytch.com/docs/b2b/api/org-auth-settings) resource to learn
      * more about fields like `email_jit_provisioning`, `email_invites`, `sso_jit_provisioning`, etc., and their behaviors.
@@ -106,8 +106,8 @@ public interface Organizations {
     ): StytchResult<UpdateResponse>
 
     /**
-     * Updates an Organization specified by `organization_id`. An Organization must always have at least one auth setting set
-     * to either `RESTRICTED` or `ALL_ALLOWED` in order to provision new Members.
+     * Updates an specified by `organization_id`. An Organization must always have at least one auth setting set to either
+     * `RESTRICTED` or `ALL_ALLOWED` in order to provision new Members.
      *
      * *See the [Organization authentication settings](https://stytch.com/docs/b2b/api/org-auth-settings) resource to learn
      * more about fields like `email_jit_provisioning`, `email_invites`, `sso_jit_provisioning`, etc., and their behaviors.
@@ -119,8 +119,8 @@ public interface Organizations {
     )
 
     /**
-     * Updates an Organization specified by `organization_id`. An Organization must always have at least one auth setting set
-     * to either `RESTRICTED` or `ALL_ALLOWED` in order to provision new Members.
+     * Updates an specified by `organization_id`. An Organization must always have at least one auth setting set to either
+     * `RESTRICTED` or `ALL_ALLOWED` in order to provision new Members.
      *
      * *See the [Organization authentication settings](https://stytch.com/docs/b2b/api/org-auth-settings) resource to learn
      * more about fields like `email_jit_provisioning`, `email_invites`, `sso_jit_provisioning`, etc., and their behaviors.
@@ -131,7 +131,7 @@ public interface Organizations {
     ): CompletableFuture<StytchResult<UpdateResponse>>
 
     /**
-     * Deletes an Organization specified by `organization_id`. All Members of the Organization will also be deleted.
+     * Deletes an specified by `organization_id`. All Members of the Organization will also be deleted.
      */
     public suspend fun delete(
         data: DeleteRequest,
@@ -139,7 +139,7 @@ public interface Organizations {
     ): StytchResult<DeleteResponse>
 
     /**
-     * Deletes an Organization specified by `organization_id`. All Members of the Organization will also be deleted.
+     * Deletes an specified by `organization_id`. All Members of the Organization will also be deleted.
      */
     public fun delete(
         data: DeleteRequest,
@@ -148,7 +148,7 @@ public interface Organizations {
     )
 
     /**
-     * Deletes an Organization specified by `organization_id`. All Members of the Organization will also be deleted.
+     * Deletes an specified by `organization_id`. All Members of the Organization will also be deleted.
      */
     public fun deleteCompletable(
         data: DeleteRequest,

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/organizationsmembers/OrganizationsMembers.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/organizationsmembers/OrganizationsMembers.kt
@@ -56,7 +56,7 @@ public interface Members {
     public val oauthProviders: OAuthProviders
 
     /**
-     * Updates a Member specified by `organization_id` and `member_id`.
+     * Updates a specified by `organization_id` and `member_id`.
      */
     public suspend fun update(
         data: UpdateRequest,
@@ -64,7 +64,7 @@ public interface Members {
     ): StytchResult<UpdateResponse>
 
     /**
-     * Updates a Member specified by `organization_id` and `member_id`.
+     * Updates a specified by `organization_id` and `member_id`.
      */
     public fun update(
         data: UpdateRequest,
@@ -73,7 +73,7 @@ public interface Members {
     )
 
     /**
-     * Updates a Member specified by `organization_id` and `member_id`.
+     * Updates a specified by `organization_id` and `member_id`.
      */
     public fun updateCompletable(
         data: UpdateRequest,
@@ -81,7 +81,7 @@ public interface Members {
     ): CompletableFuture<StytchResult<UpdateResponse>>
 
     /**
-     * Deletes a Member specified by `organization_id` and `member_id`.
+     * Deletes a specified by `organization_id` and `member_id`.
      */
     public suspend fun delete(
         data: DeleteRequest,
@@ -89,7 +89,7 @@ public interface Members {
     ): StytchResult<DeleteResponse>
 
     /**
-     * Deletes a Member specified by `organization_id` and `member_id`.
+     * Deletes a specified by `organization_id` and `member_id`.
      */
     public fun delete(
         data: DeleteRequest,
@@ -98,7 +98,7 @@ public interface Members {
     )
 
     /**
-     * Deletes a Member specified by `organization_id` and `member_id`.
+     * Deletes a specified by `organization_id` and `member_id`.
      */
     public fun deleteCompletable(
         data: DeleteRequest,
@@ -106,7 +106,7 @@ public interface Members {
     ): CompletableFuture<StytchResult<DeleteResponse>>
 
     /**
-     * Reactivates a deleted Member's status and its associated email status (if applicable) to active, specified by
+     * Reactivates a deleted's status and its associated email status (if applicable) to active, specified by
      * `organization_id` and `member_id`.
      */
     public suspend fun reactivate(
@@ -115,7 +115,7 @@ public interface Members {
     ): StytchResult<ReactivateResponse>
 
     /**
-     * Reactivates a deleted Member's status and its associated email status (if applicable) to active, specified by
+     * Reactivates a deleted's status and its associated email status (if applicable) to active, specified by
      * `organization_id` and `member_id`.
      */
     public fun reactivate(
@@ -125,7 +125,7 @@ public interface Members {
     )
 
     /**
-     * Reactivates a deleted Member's status and its associated email status (if applicable) to active, specified by
+     * Reactivates a deleted's status and its associated email status (if applicable) to active, specified by
      * `organization_id` and `member_id`.
      */
     public fun reactivateCompletable(
@@ -134,7 +134,7 @@ public interface Members {
     ): CompletableFuture<StytchResult<ReactivateResponse>>
 
     /**
-     * Delete a Member's MFA phone number.
+     * Delete a's MFA phone number.
      *
      * To change a Member's phone number, you must first call this endpoint to delete the existing phone number.
      *
@@ -151,7 +151,7 @@ public interface Members {
     ): StytchResult<DeleteMFAPhoneNumberResponse>
 
     /**
-     * Delete a Member's MFA phone number.
+     * Delete a's MFA phone number.
      *
      * To change a Member's phone number, you must first call this endpoint to delete the existing phone number.
      *
@@ -169,7 +169,7 @@ public interface Members {
     )
 
     /**
-     * Delete a Member's MFA phone number.
+     * Delete a's MFA phone number.
      *
      * To change a Member's phone number, you must first call this endpoint to delete the existing phone number.
      *
@@ -260,7 +260,7 @@ public interface Members {
     ): CompletableFuture<StytchResult<SearchResponse>>
 
     /**
-     * Delete a Member's password.
+     * Delete a's password.
      */
     public suspend fun deletePassword(
         data: DeletePasswordRequest,
@@ -268,7 +268,7 @@ public interface Members {
     ): StytchResult<DeletePasswordResponse>
 
     /**
-     * Delete a Member's password.
+     * Delete a's password.
      */
     public fun deletePassword(
         data: DeletePasswordRequest,
@@ -277,7 +277,7 @@ public interface Members {
     )
 
     /**
-     * Delete a Member's password.
+     * Delete a's password.
      */
     public fun deletePasswordCompletable(
         data: DeletePasswordRequest,
@@ -309,7 +309,7 @@ public interface Members {
     public fun dangerouslyGetCompletable(data: DangerouslyGetRequest): CompletableFuture<StytchResult<GetResponse>>
 
     /**
-     * Unlinks a retired email address from a Member specified by their `organization_id` and `member_id`. The email address
+     * Unlinks a retired email address from a specified by their `organization_id` and `member_id`. The email address
      * to be retired can be identified in the request body by either its `email_id`, its `email_address`, or both. If using
      * both identifiers they must refer to the same email.
      *
@@ -330,7 +330,7 @@ public interface Members {
     ): StytchResult<UnlinkRetiredEmailResponse>
 
     /**
-     * Unlinks a retired email address from a Member specified by their `organization_id` and `member_id`. The email address
+     * Unlinks a retired email address from a specified by their `organization_id` and `member_id`. The email address
      * to be retired can be identified in the request body by either its `email_id`, its `email_address`, or both. If using
      * both identifiers they must refer to the same email.
      *
@@ -352,7 +352,7 @@ public interface Members {
     )
 
     /**
-     * Unlinks a retired email address from a Member specified by their `organization_id` and `member_id`. The email address
+     * Unlinks a retired email address from a specified by their `organization_id` and `member_id`. The email address
      * to be retired can be identified in the request body by either its `email_id`, its `email_address`, or both. If using
      * both identifiers they must refer to the same email.
      *
@@ -373,7 +373,7 @@ public interface Members {
     ): CompletableFuture<StytchResult<UnlinkRetiredEmailResponse>>
 
     /**
-     * Creates a Member. An `organization_id` and `email_address` are required.
+     * Creates a. An `organization_id` and `email_address` are required.
      */
     public suspend fun create(
         data: CreateRequest,
@@ -381,7 +381,7 @@ public interface Members {
     ): StytchResult<CreateResponse>
 
     /**
-     * Creates a Member. An `organization_id` and `email_address` are required.
+     * Creates a. An `organization_id` and `email_address` are required.
      */
     public fun create(
         data: CreateRequest,
@@ -390,7 +390,7 @@ public interface Members {
     )
 
     /**
-     * Creates a Member. An `organization_id` and `email_address` are required.
+     * Creates a. An `organization_id` and `email_address` are required.
      */
     public fun createCompletable(
         data: CreateRequest,

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/otpsms/OTPSms.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/otpsms/OTPSms.kt
@@ -24,7 +24,7 @@ import java.util.concurrent.CompletableFuture
 
 public interface Sms {
     /**
-     * Send a One-Time Passcode (OTP) to a Member's phone number.
+     * Send a One-Time Passcode (OTP) to a's phone number.
      *
      * If the Member already has a phone number, the `mfa_phone_number` field is not needed; the endpoint will send an OTP to
      * the number associated with the Member.
@@ -60,7 +60,7 @@ public interface Sms {
     public suspend fun send(data: SendRequest): StytchResult<SendResponse>
 
     /**
-     * Send a One-Time Passcode (OTP) to a Member's phone number.
+     * Send a One-Time Passcode (OTP) to a's phone number.
      *
      * If the Member already has a phone number, the `mfa_phone_number` field is not needed; the endpoint will send an OTP to
      * the number associated with the Member.
@@ -99,7 +99,7 @@ public interface Sms {
     )
 
     /**
-     * Send a One-Time Passcode (OTP) to a Member's phone number.
+     * Send a One-Time Passcode (OTP) to a's phone number.
      *
      * If the Member already has a phone number, the `mfa_phone_number` field is not needed; the endpoint will send an OTP to
      * the number associated with the Member.
@@ -151,8 +151,8 @@ public interface Sms {
      * or upon successful calls to discovery authenticate methods, such as
      * [email magic link discovery authenticate](https://stytch.com/docs/b2b/api/authenticate-discovery-magic-link).
      *
-     * If the Organization's MFA policy is `REQUIRED_FOR_ALL`, a successful OTP authentication will change the Member's
-     * `mfa_enrolled` status to `true` if it is not already `true`.
+     * If the's MFA policy is `REQUIRED_FOR_ALL`, a successful OTP authentication will change the's `mfa_enrolled` status to
+     * `true` if it is not already `true`.
      * If the Organization's MFA policy is `OPTIONAL`, the Member's MFA enrollment can be toggled by passing in a value for
      * the `set_mfa_enrollment` field.
      * The Member's MFA enrollment can also be toggled through the
@@ -180,8 +180,8 @@ public interface Sms {
      * or upon successful calls to discovery authenticate methods, such as
      * [email magic link discovery authenticate](https://stytch.com/docs/b2b/api/authenticate-discovery-magic-link).
      *
-     * If the Organization's MFA policy is `REQUIRED_FOR_ALL`, a successful OTP authentication will change the Member's
-     * `mfa_enrolled` status to `true` if it is not already `true`.
+     * If the's MFA policy is `REQUIRED_FOR_ALL`, a successful OTP authentication will change the's `mfa_enrolled` status to
+     * `true` if it is not already `true`.
      * If the Organization's MFA policy is `OPTIONAL`, the Member's MFA enrollment can be toggled by passing in a value for
      * the `set_mfa_enrollment` field.
      * The Member's MFA enrollment can also be toggled through the
@@ -212,8 +212,8 @@ public interface Sms {
      * or upon successful calls to discovery authenticate methods, such as
      * [email magic link discovery authenticate](https://stytch.com/docs/b2b/api/authenticate-discovery-magic-link).
      *
-     * If the Organization's MFA policy is `REQUIRED_FOR_ALL`, a successful OTP authentication will change the Member's
-     * `mfa_enrolled` status to `true` if it is not already `true`.
+     * If the's MFA policy is `REQUIRED_FOR_ALL`, a successful OTP authentication will change the's `mfa_enrolled` status to
+     * `true` if it is not already `true`.
      * If the Organization's MFA policy is `OPTIONAL`, the Member's MFA enrollment can be toggled by passing in a value for
      * the `set_mfa_enrollment` field.
      * The Member's MFA enrollment can also be toggled through the

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/passwords/Passwords.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/passwords/Passwords.kt
@@ -155,8 +155,8 @@ public interface Passwords {
      * member enters a correct password. We force a password reset in this case to ensure that the member is the legitimate
      * owner of the email address and not a malicious actor abusing the compromised credentials.
      *
-     * If the Member is required to complete MFA to log in to the Organization, the returned value of `member_authenticated`
-     * will be `false`, and an `intermediate_session_token` will be returned.
+     * If the is required to complete MFA to log in to the, the returned value of `member_authenticated` will be `false`, and
+     * an `intermediate_session_token` will be returned.
      * The `intermediate_session_token` can be passed into the
      * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms) to complete the MFA step and
      * acquire a full member session.
@@ -176,8 +176,8 @@ public interface Passwords {
      * member enters a correct password. We force a password reset in this case to ensure that the member is the legitimate
      * owner of the email address and not a malicious actor abusing the compromised credentials.
      *
-     * If the Member is required to complete MFA to log in to the Organization, the returned value of `member_authenticated`
-     * will be `false`, and an `intermediate_session_token` will be returned.
+     * If the is required to complete MFA to log in to the, the returned value of `member_authenticated` will be `false`, and
+     * an `intermediate_session_token` will be returned.
      * The `intermediate_session_token` can be passed into the
      * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms) to complete the MFA step and
      * acquire a full member session.
@@ -200,8 +200,8 @@ public interface Passwords {
      * member enters a correct password. We force a password reset in this case to ensure that the member is the legitimate
      * owner of the email address and not a malicious actor abusing the compromised credentials.
      *
-     * If the Member is required to complete MFA to log in to the Organization, the returned value of `member_authenticated`
-     * will be `false`, and an `intermediate_session_token` will be returned.
+     * If the is required to complete MFA to log in to the, the returned value of `member_authenticated` will be `false`, and
+     * an `intermediate_session_token` will be returned.
      * The `intermediate_session_token` can be passed into the
      * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms) to complete the MFA step and
      * acquire a full member session.

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/passwordsemail/PasswordsEmail.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/passwordsemail/PasswordsEmail.kt
@@ -72,7 +72,7 @@ public interface Email {
     public fun resetStartCompletable(data: ResetStartRequest): CompletableFuture<StytchResult<ResetStartResponse>>
 
     /**
-     * Reset the member's password and authenticate them. This endpoint checks that the password reset token is valid, hasn’t
+     * Reset the's password and authenticate them. This endpoint checks that the password reset token is valid, hasn’t
      * expired, or already been used.
      *
      * The provided password needs to meet our password strength requirements, which can be checked in advance with the
@@ -93,7 +93,7 @@ public interface Email {
     public suspend fun reset(data: ResetRequest): StytchResult<ResetResponse>
 
     /**
-     * Reset the member's password and authenticate them. This endpoint checks that the password reset token is valid, hasn’t
+     * Reset the's password and authenticate them. This endpoint checks that the password reset token is valid, hasn’t
      * expired, or already been used.
      *
      * The provided password needs to meet our password strength requirements, which can be checked in advance with the
@@ -117,7 +117,7 @@ public interface Email {
     )
 
     /**
-     * Reset the member's password and authenticate them. This endpoint checks that the password reset token is valid, hasn’t
+     * Reset the's password and authenticate them. This endpoint checks that the password reset token is valid, hasn’t
      * expired, or already been used.
      *
      * The provided password needs to meet our password strength requirements, which can be checked in advance with the

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/passwordsexistingpassword/PasswordsExistingPassword.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/passwordsexistingpassword/PasswordsExistingPassword.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.CompletableFuture
 
 public interface ExistingPassword {
     /**
-     * Reset the member’s password using their existing password.
+     * Reset the’s password using their existing password.
      *
      * This endpoint adapts to your Project's password strength configuration.
      * If you're using [zxcvbn](https://stytch.com/docs/guides/passwords/strength-policy), the default, your passwords are
@@ -47,7 +47,7 @@ public interface ExistingPassword {
     public suspend fun reset(data: ResetRequest): StytchResult<ResetResponse>
 
     /**
-     * Reset the member’s password using their existing password.
+     * Reset the’s password using their existing password.
      *
      * This endpoint adapts to your Project's password strength configuration.
      * If you're using [zxcvbn](https://stytch.com/docs/guides/passwords/strength-policy), the default, your passwords are
@@ -75,7 +75,7 @@ public interface ExistingPassword {
     )
 
     /**
-     * Reset the member’s password using their existing password.
+     * Reset the’s password using their existing password.
      *
      * This endpoint adapts to your Project's password strength configuration.
      * If you're using [zxcvbn](https://stytch.com/docs/guides/passwords/strength-policy), the default, your passwords are

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/passwordssession/PasswordsSession.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/passwordssession/PasswordsSession.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.CompletableFuture
 
 public interface Sessions {
     /**
-     * Reset the Member's password using their existing session. The endpoint will error if the session does not contain an
+     * Reset the's password using their existing session. The endpoint will error if the session does not contain an
      * authentication factor that has been issued within the last 5 minutes. Either `session_token` or `session_jwt` should be
      * provided.
      *
@@ -32,7 +32,7 @@ public interface Sessions {
     public suspend fun reset(data: ResetRequest): StytchResult<ResetResponse>
 
     /**
-     * Reset the Member's password using their existing session. The endpoint will error if the session does not contain an
+     * Reset the's password using their existing session. The endpoint will error if the session does not contain an
      * authentication factor that has been issued within the last 5 minutes. Either `session_token` or `session_jwt` should be
      * provided.
      *
@@ -45,7 +45,7 @@ public interface Sessions {
     )
 
     /**
-     * Reset the Member's password using their existing session. The endpoint will error if the session does not contain an
+     * Reset the's password using their existing session. The endpoint will error if the session does not contain an
      * authentication factor that has been issued within the last 5 minutes. Either `session_token` or `session_jwt` should be
      * provided.
      *

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/recoverycodes/RecoveryCodes.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/recoverycodes/RecoveryCodes.kt
@@ -28,14 +28,14 @@ import java.util.concurrent.CompletableFuture
 
 public interface RecoveryCodes {
     /**
-     * Allows a Member to complete an MFA flow by consuming a recovery code. This consumes the recovery code and returns a
-     * session token that can be used to authenticate the Member.
+     * Allows a to complete an MFA flow by consuming a recovery code. This consumes the recovery code and returns a session
+     * token that can be used to authenticate the Member.
      */
     public suspend fun recover(data: RecoverRequest): StytchResult<RecoverResponse>
 
     /**
-     * Allows a Member to complete an MFA flow by consuming a recovery code. This consumes the recovery code and returns a
-     * session token that can be used to authenticate the Member.
+     * Allows a to complete an MFA flow by consuming a recovery code. This consumes the recovery code and returns a session
+     * token that can be used to authenticate the Member.
      */
     public fun recover(
         data: RecoverRequest,
@@ -43,18 +43,18 @@ public interface RecoveryCodes {
     )
 
     /**
-     * Allows a Member to complete an MFA flow by consuming a recovery code. This consumes the recovery code and returns a
-     * session token that can be used to authenticate the Member.
+     * Allows a to complete an MFA flow by consuming a recovery code. This consumes the recovery code and returns a session
+     * token that can be used to authenticate the Member.
      */
     public fun recoverCompletable(data: RecoverRequest): CompletableFuture<StytchResult<RecoverResponse>>
 
     /**
-     * Returns a Member's full set of active recovery codes.
+     * Returns a's full set of active recovery codes.
      */
     public suspend fun get(data: GetRequest): StytchResult<GetResponse>
 
     /**
-     * Returns a Member's full set of active recovery codes.
+     * Returns a's full set of active recovery codes.
      */
     public fun get(
         data: GetRequest,
@@ -62,19 +62,17 @@ public interface RecoveryCodes {
     )
 
     /**
-     * Returns a Member's full set of active recovery codes.
+     * Returns a's full set of active recovery codes.
      */
     public fun getCompletable(data: GetRequest): CompletableFuture<StytchResult<GetResponse>>
 
     /**
-     * Rotate a Member's recovery codes. This invalidates all existing recovery codes and generates a new set of recovery
-     * codes.
+     * Rotate a's recovery codes. This invalidates all existing recovery codes and generates a new set of recovery codes.
      */
     public suspend fun rotate(data: RotateRequest): StytchResult<RotateResponse>
 
     /**
-     * Rotate a Member's recovery codes. This invalidates all existing recovery codes and generates a new set of recovery
-     * codes.
+     * Rotate a's recovery codes. This invalidates all existing recovery codes and generates a new set of recovery codes.
      */
     public fun rotate(
         data: RotateRequest,
@@ -82,8 +80,7 @@ public interface RecoveryCodes {
     )
 
     /**
-     * Rotate a Member's recovery codes. This invalidates all existing recovery codes and generates a new set of recovery
-     * codes.
+     * Rotate a's recovery codes. This invalidates all existing recovery codes and generates a new set of recovery codes.
      */
     public fun rotateCompletable(data: RotateRequest): CompletableFuture<StytchResult<RotateResponse>>
 }

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/sessions/Sessions.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/sessions/Sessions.kt
@@ -74,9 +74,8 @@ public interface Sessions {
      * information.
      *
      * If an `authorization_check` object is passed in, this method will also check if the Member is authorized to perform the
-     * given action on the given Resource in the specified Organization. A Member is authorized if their Member Session
-     * contains a Role, assigned [explicitly or implicitly](https://stytch.com/docs/b2b/guides/rbac/role-assignment), with
-     * adequate permissions.
+     * given action on the given Resource in the specified. A is authorized if their Member Session contains a Role, assigned
+     * [explicitly or implicitly](https://stytch.com/docs/b2b/guides/rbac/role-assignment), with adequate permissions.
      * In addition, the `organization_id` passed in the authorization check must match the Member's Organization.
      *
      * If the Member is not authorized to perform the specified action on the specified Resource, or if the
@@ -96,9 +95,8 @@ public interface Sessions {
      * information.
      *
      * If an `authorization_check` object is passed in, this method will also check if the Member is authorized to perform the
-     * given action on the given Resource in the specified Organization. A Member is authorized if their Member Session
-     * contains a Role, assigned [explicitly or implicitly](https://stytch.com/docs/b2b/guides/rbac/role-assignment), with
-     * adequate permissions.
+     * given action on the given Resource in the specified. A is authorized if their Member Session contains a Role, assigned
+     * [explicitly or implicitly](https://stytch.com/docs/b2b/guides/rbac/role-assignment), with adequate permissions.
      * In addition, the `organization_id` passed in the authorization check must match the Member's Organization.
      *
      * If the Member is not authorized to perform the specified action on the specified Resource, or if the
@@ -121,9 +119,8 @@ public interface Sessions {
      * information.
      *
      * If an `authorization_check` object is passed in, this method will also check if the Member is authorized to perform the
-     * given action on the given Resource in the specified Organization. A Member is authorized if their Member Session
-     * contains a Role, assigned [explicitly or implicitly](https://stytch.com/docs/b2b/guides/rbac/role-assignment), with
-     * adequate permissions.
+     * given action on the given Resource in the specified. A is authorized if their Member Session contains a Role, assigned
+     * [explicitly or implicitly](https://stytch.com/docs/b2b/guides/rbac/role-assignment), with adequate permissions.
      * In addition, the `organization_id` passed in the authorization check must match the Member's Organization.
      *
      * If the Member is not authorized to perform the specified action on the specified Resource, or if the
@@ -161,8 +158,8 @@ public interface Sessions {
     ): CompletableFuture<StytchResult<RevokeResponse>>
 
     /**
-     * Use this endpoint to exchange a Member's existing session for another session in a different Organization. This can be
-     * used to accept an invite, but not to create a new member via domain matching.
+     * Use this endpoint to exchange a's existing session for another session in a different. This can be used to accept an
+     * invite, but not to create a new member via domain matching.
      *
      * To create a new member via domain matching, use the
      * [Exchange Intermediate Session](https://stytch.com/docs/b2b/api/exchange-intermediate-session) flow instead.
@@ -172,6 +169,8 @@ public interface Sessions {
      * Any OAuth Tokens owned by the Member will not be transferred to the new Organization.
      * SMS OTP factors can be used to fulfill MFA requirements for the target Organization if both the original and target
      * Member have the same phone number and the phone number is verified for both Members.
+     * HubSpot and Slack OAuth registrations will not be transferred between sessions. Instead, you will receive a
+     * corresponding factor with type `"oauth_exchange_slack"` or `"oauth_exchange_hubspot"`
      *
      * If the Member is required to complete MFA to log in to the Organization, the returned value of `member_authenticated`
      * will be `false`, and an `intermediate_session_token` will be returned.
@@ -187,8 +186,8 @@ public interface Sessions {
     public suspend fun exchange(data: ExchangeRequest): StytchResult<ExchangeResponse>
 
     /**
-     * Use this endpoint to exchange a Member's existing session for another session in a different Organization. This can be
-     * used to accept an invite, but not to create a new member via domain matching.
+     * Use this endpoint to exchange a's existing session for another session in a different. This can be used to accept an
+     * invite, but not to create a new member via domain matching.
      *
      * To create a new member via domain matching, use the
      * [Exchange Intermediate Session](https://stytch.com/docs/b2b/api/exchange-intermediate-session) flow instead.
@@ -198,6 +197,8 @@ public interface Sessions {
      * Any OAuth Tokens owned by the Member will not be transferred to the new Organization.
      * SMS OTP factors can be used to fulfill MFA requirements for the target Organization if both the original and target
      * Member have the same phone number and the phone number is verified for both Members.
+     * HubSpot and Slack OAuth registrations will not be transferred between sessions. Instead, you will receive a
+     * corresponding factor with type `"oauth_exchange_slack"` or `"oauth_exchange_hubspot"`
      *
      * If the Member is required to complete MFA to log in to the Organization, the returned value of `member_authenticated`
      * will be `false`, and an `intermediate_session_token` will be returned.
@@ -216,8 +217,8 @@ public interface Sessions {
     )
 
     /**
-     * Use this endpoint to exchange a Member's existing session for another session in a different Organization. This can be
-     * used to accept an invite, but not to create a new member via domain matching.
+     * Use this endpoint to exchange a's existing session for another session in a different. This can be used to accept an
+     * invite, but not to create a new member via domain matching.
      *
      * To create a new member via domain matching, use the
      * [Exchange Intermediate Session](https://stytch.com/docs/b2b/api/exchange-intermediate-session) flow instead.
@@ -227,6 +228,8 @@ public interface Sessions {
      * Any OAuth Tokens owned by the Member will not be transferred to the new Organization.
      * SMS OTP factors can be used to fulfill MFA requirements for the target Organization if both the original and target
      * Member have the same phone number and the phone number is verified for both Members.
+     * HubSpot and Slack OAuth registrations will not be transferred between sessions. Instead, you will receive a
+     * corresponding factor with type `"oauth_exchange_slack"` or `"oauth_exchange_hubspot"`
      *
      * If the Member is required to complete MFA to log in to the Organization, the returned value of `member_authenticated`
      * will be `false`, and an `intermediate_session_token` will be returned.
@@ -244,16 +247,16 @@ public interface Sessions {
     /**
      * Migrate a session from an external OIDC compliant endpoint. Stytch will call the external UserInfo endpoint defined in
      * your Stytch Project settings in the [Dashboard](/dashboard), and then perform a lookup using the `session_token`. If
-     * the response contains a valid email address, Stytch will attempt to match that email address with an existing Member in
-     * your Organization and create a Stytch Session. You will need to create the member before using this endpoint.
+     * the response contains a valid email address, Stytch will attempt to match that email address with an existing in your
+     * and create a Stytch Session. You will need to create the member before using this endpoint.
      */
     public suspend fun migrate(data: MigrateRequest): StytchResult<MigrateResponse>
 
     /**
      * Migrate a session from an external OIDC compliant endpoint. Stytch will call the external UserInfo endpoint defined in
      * your Stytch Project settings in the [Dashboard](/dashboard), and then perform a lookup using the `session_token`. If
-     * the response contains a valid email address, Stytch will attempt to match that email address with an existing Member in
-     * your Organization and create a Stytch Session. You will need to create the member before using this endpoint.
+     * the response contains a valid email address, Stytch will attempt to match that email address with an existing in your
+     * and create a Stytch Session. You will need to create the member before using this endpoint.
      */
     public fun migrate(
         data: MigrateRequest,
@@ -263,8 +266,8 @@ public interface Sessions {
     /**
      * Migrate a session from an external OIDC compliant endpoint. Stytch will call the external UserInfo endpoint defined in
      * your Stytch Project settings in the [Dashboard](/dashboard), and then perform a lookup using the `session_token`. If
-     * the response contains a valid email address, Stytch will attempt to match that email address with an existing Member in
-     * your Organization and create a Stytch Session. You will need to create the member before using this endpoint.
+     * the response contains a valid email address, Stytch will attempt to match that email address with an existing in your
+     * and create a Stytch Session. You will need to create the member before using this endpoint.
      */
     public fun migrateCompletable(data: MigrateRequest): CompletableFuture<StytchResult<MigrateResponse>>
 

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/sso/SSO.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/sso/SSO.kt
@@ -97,8 +97,8 @@ public interface SSO {
      * To link this authentication event to an existing Stytch session, include either the `session_token` or `session_jwt`
      * param.
      *
-     * If the Member is required to complete MFA to log in to the Organization, the returned value of `member_authenticated`
-     * will be `false`, and an `intermediate_session_token` will be returned.
+     * If the is required to complete MFA to log in to the, the returned value of `member_authenticated` will be `false`, and
+     * an `intermediate_session_token` will be returned.
      * The `intermediate_session_token` can be passed into the
      * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
      * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
@@ -120,8 +120,8 @@ public interface SSO {
      * To link this authentication event to an existing Stytch session, include either the `session_token` or `session_jwt`
      * param.
      *
-     * If the Member is required to complete MFA to log in to the Organization, the returned value of `member_authenticated`
-     * will be `false`, and an `intermediate_session_token` will be returned.
+     * If the is required to complete MFA to log in to the, the returned value of `member_authenticated` will be `false`, and
+     * an `intermediate_session_token` will be returned.
      * The `intermediate_session_token` can be passed into the
      * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
      * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),
@@ -146,8 +146,8 @@ public interface SSO {
      * To link this authentication event to an existing Stytch session, include either the `session_token` or `session_jwt`
      * param.
      *
-     * If the Member is required to complete MFA to log in to the Organization, the returned value of `member_authenticated`
-     * will be `false`, and an `intermediate_session_token` will be returned.
+     * If the is required to complete MFA to log in to the, the returned value of `member_authenticated` will be `false`, and
+     * an `intermediate_session_token` will be returned.
      * The `intermediate_session_token` can be passed into the
      * [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
      * [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp),

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/totps/TOTPs.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/totps/TOTPs.kt
@@ -26,8 +26,8 @@ import java.util.concurrent.CompletableFuture
 
 public interface TOTPs {
     /**
-     * Create a new TOTP instance for a Member. The Member can use the authenticator application of their choice to scan the
-     * QR code or enter the secret.
+     * Create a new TOTP instance for a. The Member can use the authenticator application of their choice to scan the QR code
+     * or enter the secret.
      *
      * Passing an intermediate session token, session token, or session JWT is not required, but if passed must match the
      * Member ID passed.
@@ -35,8 +35,8 @@ public interface TOTPs {
     public suspend fun create(data: CreateRequest): StytchResult<CreateResponse>
 
     /**
-     * Create a new TOTP instance for a Member. The Member can use the authenticator application of their choice to scan the
-     * QR code or enter the secret.
+     * Create a new TOTP instance for a. The Member can use the authenticator application of their choice to scan the QR code
+     * or enter the secret.
      *
      * Passing an intermediate session token, session token, or session JWT is not required, but if passed must match the
      * Member ID passed.
@@ -47,8 +47,8 @@ public interface TOTPs {
     )
 
     /**
-     * Create a new TOTP instance for a Member. The Member can use the authenticator application of their choice to scan the
-     * QR code or enter the secret.
+     * Create a new TOTP instance for a. The Member can use the authenticator application of their choice to scan the QR code
+     * or enter the secret.
      *
      * Passing an intermediate session token, session token, or session JWT is not required, but if passed must match the
      * Member ID passed.
@@ -74,14 +74,14 @@ public interface TOTPs {
     public fun authenticateCompletable(data: AuthenticateRequest): CompletableFuture<StytchResult<AuthenticateResponse>>
 
     /**
-     * Migrate an existing TOTP instance for a Member. Recovery codes are not required and will be minted for the Member if
-     * not provided.
+     * Migrate an existing TOTP instance for a. Recovery codes are not required and will be minted for the Member if not
+     * provided.
      */
     public suspend fun migrate(data: MigrateRequest): StytchResult<MigrateResponse>
 
     /**
-     * Migrate an existing TOTP instance for a Member. Recovery codes are not required and will be minted for the Member if
-     * not provided.
+     * Migrate an existing TOTP instance for a. Recovery codes are not required and will be minted for the Member if not
+     * provided.
      */
     public fun migrate(
         data: MigrateRequest,
@@ -89,8 +89,8 @@ public interface TOTPs {
     )
 
     /**
-     * Migrate an existing TOTP instance for a Member. Recovery codes are not required and will be minted for the Member if
-     * not provided.
+     * Migrate an existing TOTP instance for a. Recovery codes are not required and will be minted for the Member if not
+     * provided.
      */
     public fun migrateCompletable(data: MigrateRequest): CompletableFuture<StytchResult<MigrateResponse>>
 }

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/discoveryintermediatesessions/DiscoveryIntermediateSessions.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/discoveryintermediatesessions/DiscoveryIntermediateSessions.kt
@@ -82,7 +82,7 @@ public data class ExchangeRequest
         @Json(name = "session_custom_claims")
         val sessionCustomClaims: Map<String, Any?>? = emptyMap(),
         /**
-         * If the Member needs to complete an MFA step, and the Member has a phone number, this endpoint will pre-emptively send a
+         * If the needs to complete an MFA step, and the Member has a phone number, this endpoint will pre-emptively send a
          * one-time passcode (OTP) to the Member's phone number. The locale argument will be used to determine which language to
          * use when sending the passcode.
          *
@@ -173,6 +173,9 @@ public data class ExchangeResponse
          */
         @Json(name = "mfa_required")
         val mfaRequired: MfaRequired? = null,
+        /**
+         * Information about the primary authentication requirements of the Organization.
+         */
         @Json(name = "primary_required")
         val primaryRequired: PrimaryRequired? = null,
     )

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/discoveryorganizations/DiscoveryOrganizations.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/discoveryorganizations/DiscoveryOrganizations.kt
@@ -294,6 +294,9 @@ public data class CreateResponse
          */
         @Json(name = "mfa_required")
         val mfaRequired: MfaRequired? = null,
+        /**
+         * Information about the primary authentication requirements of the Organization.
+         */
         @Json(name = "primary_required")
         val primaryRequired: PrimaryRequired? = null,
     )

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/magiclinks/MagicLinks.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/magiclinks/MagicLinks.kt
@@ -89,7 +89,7 @@ public data class AuthenticateRequest
         @Json(name = "session_custom_claims")
         val sessionCustomClaims: Map<String, Any?>? = emptyMap(),
         /**
-         * If the Member needs to complete an MFA step, and the Member has a phone number, this endpoint will pre-emptively send a
+         * If the needs to complete an MFA step, and the Member has a phone number, this endpoint will pre-emptively send a
          * one-time passcode (OTP) to the Member's phone number. The locale argument will be used to determine which language to
          * use when sending the passcode.
          *

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/oauth/OAuth.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/oauth/OAuth.kt
@@ -114,7 +114,7 @@ public data class AuthenticateRequest
         @Json(name = "pkce_code_verifier")
         val pkceCodeVerifier: String? = null,
         /**
-         * If the Member needs to complete an MFA step, and the Member has a phone number, this endpoint will pre-emptively send a
+         * If the needs to complete an MFA step, and the Member has a phone number, this endpoint will pre-emptively send a
          * one-time passcode (OTP) to the Member's phone number. The locale argument will be used to determine which language to
          * use when sending the passcode.
          *
@@ -240,6 +240,9 @@ public data class AuthenticateResponse
          */
         @Json(name = "mfa_required")
         val mfaRequired: MfaRequired? = null,
+        /**
+         * Information about the primary authentication requirements of the Organization.
+         */
         @Json(name = "primary_required")
         val primaryRequired: PrimaryRequired? = null,
     )

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwords/Passwords.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwords/Passwords.kt
@@ -176,7 +176,7 @@ public data class AuthenticateRequest
         @Json(name = "session_custom_claims")
         val sessionCustomClaims: Map<String, Any?>? = emptyMap(),
         /**
-         * If the Member needs to complete an MFA step, and the Member has a phone number, this endpoint will pre-emptively send a
+         * If the needs to complete an MFA step, and the Member has a phone number, this endpoint will pre-emptively send a
          * one-time passcode (OTP) to the Member's phone number. The locale argument will be used to determine which language to
          * use when sending the passcode.
          *
@@ -297,7 +297,7 @@ public data class MigrateRequest
         @Json(name = "hash")
         val hash: String,
         /**
-         * The password hash used. Currently `bcrypt`, `scrypt`, `argon2i`, `argon2id`, `md_5`, `sha_1`, and `pbkdf_2` are
+         * The password hash used. Currently `bcrypt`, `scrypt`, `argon_2i`, `argon2_id`, `md_5`, `sha_1`, and `pbkdf_2` are
          * supported.
          */
         @Json(name = "hash_type")

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwordsemail/PasswordsEmail.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwordsemail/PasswordsEmail.kt
@@ -107,7 +107,7 @@ public data class ResetRequest
         @Json(name = "session_custom_claims")
         val sessionCustomClaims: Map<String, Any?>? = emptyMap(),
         /**
-         * If the Member needs to complete an MFA step, and the Member has a phone number, this endpoint will pre-emptively send a
+         * If the needs to complete an MFA step, and the Member has a phone number, this endpoint will pre-emptively send a
          * one-time passcode (OTP) to the Member's phone number. The locale argument will be used to determine which language to
          * use when sending the passcode.
          *

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwordsexistingpassword/PasswordsExistingPassword.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/passwordsexistingpassword/PasswordsExistingPassword.kt
@@ -92,7 +92,7 @@ public data class ResetRequest
         @Json(name = "session_custom_claims")
         val sessionCustomClaims: Map<String, Any?>? = emptyMap(),
         /**
-         * If the Member needs to complete an MFA step, and the Member has a phone number, this endpoint will pre-emptively send a
+         * If the needs to complete an MFA step, and the Member has a phone number, this endpoint will pre-emptively send a
          * one-time passcode (OTP) to the Member's phone number. The locale argument will be used to determine which language to
          * use when sending the passcode.
          *

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/sessions/Sessions.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/sessions/Sessions.kt
@@ -130,10 +130,9 @@ public data class PrimaryRequired
     @JvmOverloads
     constructor(
         /**
-         * If non-empty, indicates that the Organization restricts the authentication methods it allows for login (such as `sso`
-         * or `password`), and the end user must complete one of those authentication methods to log in. If empty, indicates that
-         * the Organization does not restrict the authentication method it allows for login, but the end user does not have any
-         * transferrable primary factors. Only email magic link and OAuth factors can be transferred between Organizations.
+         * Details the auth method that the member must also complete to fulfill the primary authentication requirements of the
+         * Organization. For example, a value of `[magic_link]` indicates that the Member must also complete a magic link
+         * authentication step. If you have an intermediate session token, you must pass it into that primary authentication step.
          */
         @Json(name = "allowed_auth_methods")
         val allowedAuthMethods: List<String>,
@@ -327,7 +326,7 @@ public data class ExchangeRequest
         @Json(name = "session_custom_claims")
         val sessionCustomClaims: Map<String, Any?>? = emptyMap(),
         /**
-         * If the Member needs to complete an MFA step, and the Member has a phone number, this endpoint will pre-emptively send a
+         * If the needs to complete an MFA step, and the Member has a phone number, this endpoint will pre-emptively send a
          * one-time passcode (OTP) to the Member's phone number. The locale argument will be used to determine which language to
          * use when sending the passcode.
          *

--- a/stytch/src/main/kotlin/com/stytch/java/b2b/models/sso/SSO.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/models/sso/SSO.kt
@@ -43,6 +43,18 @@ public data class Connection
         val displayName: String,
         @Json(name = "status")
         val status: String,
+        @Json(name = "external_connection_implicit_role_assignments")
+        val externalConnectionImplicitRoleAssignments: List<ConnectionImplicitRoleAssignment>,
+        @Json(name = "external_group_implicit_role_assignments")
+        val externalGroupImplicitRoleAssignments: List<GroupImplicitRoleAssignment>,
+    )
+
+@JsonClass(generateAdapter = true)
+public data class ConnectionImplicitRoleAssignment
+    @JvmOverloads
+    constructor(
+        @Json(name = "role_id")
+        val roleId: String,
     )
 
 public data class DeleteConnectionRequestOptions
@@ -82,6 +94,16 @@ public data class GetConnectionsRequestOptions
             return res + headers
         }
     }
+
+@JsonClass(generateAdapter = true)
+public data class GroupImplicitRoleAssignment
+    @JvmOverloads
+    constructor(
+        @Json(name = "role_id")
+        val roleId: String,
+        @Json(name = "group")
+        val group: String,
+    )
 
 @JsonClass(generateAdapter = true)
 public data class OIDCConnection
@@ -270,7 +292,7 @@ public data class AuthenticateRequest
         @Json(name = "session_custom_claims")
         val sessionCustomClaims: Map<String, Any?>? = emptyMap(),
         /**
-         * If the Member needs to complete an MFA step, and the Member has a phone number, this endpoint will pre-emptively send a
+         * If the needs to complete an MFA step, and the Member has a phone number, this endpoint will pre-emptively send a
          * one-time passcode (OTP) to the Member's phone number. The locale argument will be used to determine which language to
          * use when sending the passcode.
          *

--- a/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
@@ -1,3 +1,3 @@
 package com.stytch.java.common
 
-internal const val VERSION = "5.5.1"
+internal const val VERSION = "6.0.0"

--- a/stytch/src/main/kotlin/com/stytch/java/consumer/StytchClient.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/consumer/StytchClient.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.SupervisorJob
 import org.jose4j.jwk.HttpsJwks
 
 public class StytchClient(projectId: String, secret: String) {
+    private val coroutineScope = CoroutineScope(SupervisorJob())
     private val baseUrl = getBaseUrl(projectId)
     private val httpClient: HttpClient =
         HttpClient(
@@ -50,8 +51,6 @@ public class StytchClient(projectId: String, secret: String) {
             issuer = "stytch.com/$projectId",
             type = "JWT",
         )
-
-    private val coroutineScope = CoroutineScope(SupervisorJob())
 
     @JvmField
     public val cryptoWallets: CryptoWallets = CryptoWalletsImpl(httpClient, coroutineScope)

--- a/stytch/src/main/kotlin/com/stytch/java/consumer/StytchClient.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/consumer/StytchClient.kt
@@ -35,77 +35,56 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import org.jose4j.jwk.HttpsJwks
 
-public object StytchClient {
-    private lateinit var httpClient: HttpClient
-    private lateinit var httpsJwks: HttpsJwks
-    private lateinit var jwtOptions: JwtOptions
+public class StytchClient(projectId: String, secret: String) {
+    private val baseUrl = getBaseUrl(projectId)
+    private val httpClient: HttpClient =
+        HttpClient(
+            baseUrl = baseUrl,
+            projectId = projectId,
+            secret = secret,
+        )
+    private val httpsJwks = HttpsJwks("$baseUrl/v1/sessions/jwks/$projectId")
+    private val jwtOptions: JwtOptions =
+        JwtOptions(
+            audience = projectId,
+            issuer = "stytch.com/$projectId",
+            type = "JWT",
+        )
 
-    @JvmStatic
-    public lateinit var cryptoWallets: CryptoWallets
+    private val coroutineScope = CoroutineScope(SupervisorJob())
 
-    @JvmStatic
-    public lateinit var m2m: M2M
+    @JvmField
+    public val cryptoWallets: CryptoWallets = CryptoWalletsImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public lateinit var magicLinks: MagicLinks
+    @JvmField
+    public val m2m: M2M = M2MImpl(httpClient, coroutineScope, httpsJwks, jwtOptions)
 
-    @JvmStatic
-    public lateinit var oauth: OAuth
+    @JvmField
+    public val magicLinks: MagicLinks = MagicLinksImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public lateinit var otps: OTPs
+    @JvmField
+    public val oauth: OAuth = OAuthImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public lateinit var passwords: Passwords
+    @JvmField
+    public val otps: OTPs = OTPsImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public lateinit var project: Project
+    @JvmField
+    public val passwords: Passwords = PasswordsImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public lateinit var sessions: Sessions
+    @JvmField
+    public val project: Project = ProjectImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public lateinit var totps: TOTPs
+    @JvmField
+    public val sessions: Sessions = SessionsImpl(httpClient, coroutineScope, httpsJwks, jwtOptions)
 
-    @JvmStatic
-    public lateinit var users: Users
+    @JvmField
+    public val totps: TOTPs = TOTPsImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public lateinit var webauthn: WebAuthn
+    @JvmField
+    public val users: Users = UsersImpl(httpClient, coroutineScope)
 
-    @JvmStatic
-    public fun configure(
-        projectId: String,
-        secret: String,
-    ) {
-        val baseUrl = getBaseUrl(projectId)
-        httpClient =
-            HttpClient(
-                baseUrl = baseUrl,
-                projectId = projectId,
-                secret = secret,
-            )
-        jwtOptions =
-            JwtOptions(
-                audience = projectId,
-                issuer = "stytch.com/$projectId",
-                type = "JWT",
-            )
-        val coroutineScope = CoroutineScope(SupervisorJob())
-        httpsJwks = HttpsJwks("$baseUrl/v1/sessions/jwks/$projectId")
-
-        cryptoWallets = CryptoWalletsImpl(httpClient, coroutineScope)
-        m2m = M2MImpl(httpClient, coroutineScope, httpsJwks, jwtOptions)
-        magicLinks = MagicLinksImpl(httpClient, coroutineScope)
-        oauth = OAuthImpl(httpClient, coroutineScope)
-        otps = OTPsImpl(httpClient, coroutineScope)
-        passwords = PasswordsImpl(httpClient, coroutineScope)
-        project = ProjectImpl(httpClient, coroutineScope)
-        sessions = SessionsImpl(httpClient, coroutineScope, httpsJwks, jwtOptions)
-        totps = TOTPsImpl(httpClient, coroutineScope)
-        users = UsersImpl(httpClient, coroutineScope)
-        webauthn = WebAuthnImpl(httpClient, coroutineScope)
-    }
+    @JvmField
+    public val webauthn: WebAuthn = WebAuthnImpl(httpClient, coroutineScope)
 
     /**
      * Resolve the base URL for the Stytch API environment.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,1 +1,1 @@
-version = "5.5.1"
+version = "6.0.0"

--- a/workbench/src/main/kotlin/com/stytch/workbench/Main.kt
+++ b/workbench/src/main/kotlin/com/stytch/workbench/Main.kt
@@ -3,11 +3,13 @@ import com.stytch.java.consumer.StytchClient
 import com.stytch.java.consumer.models.magiclinksemail.LoginOrCreateRequest
 
 suspend fun main() {
-    val stytchClient = StytchClient(
-        projectId = "project-test-....",
-        secret = "secret-test-....",
-    )
-    val result = stytchClient.magicLinks.email.loginOrCreate(
+    val stytchClient =
+        StytchClient(
+            projectId = "project-test-....",
+            secret = "secret-test-....",
+        )
+    val result =
+        stytchClient.magicLinks.email.loginOrCreate(
             LoginOrCreateRequest(
                 email = "email@address.com",
                 signupExpirationMinutes = 30,

--- a/workbench/src/main/kotlin/com/stytch/workbench/Main.kt
+++ b/workbench/src/main/kotlin/com/stytch/workbench/Main.kt
@@ -3,12 +3,11 @@ import com.stytch.java.consumer.StytchClient
 import com.stytch.java.consumer.models.magiclinksemail.LoginOrCreateRequest
 
 suspend fun main() {
-    StytchClient.configure(
+    val stytchClient = StytchClient(
         projectId = "project-test-....",
         secret = "secret-test-....",
     )
-    val result =
-        StytchClient.magicLinks.email.loginOrCreate(
+    val result = stytchClient.magicLinks.email.loginOrCreate(
             LoginOrCreateRequest(
                 email = "email@address.com",
                 signupExpirationMinutes = 30,


### PR DESCRIPTION
* Reruns latest codegen
* BREAKING CHANGE: StytchClient is now an instantiable class, instead of a singleton object
* Updates README

Waiting on: https://github.com/stytchauth/sdk-codegen/pull/182