### PR TITLE
Make Publishing step workflow_dispatch-able

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -37,15 +38,15 @@ jobs:
           echo "diff=$FOUND" >> $GITHUB_OUTPUT
 
       - name: Release build
-        if: steps.diff.outputs.diff != 0
+        if: steps.diff.outputs.diff != 0 || ${{ github.event_name == 'workflow_dispatch' }}
         run: ./gradlew assemble
 
       - name: Source jar
-        if: steps.diff.outputs.diff != 0
+        if: steps.diff.outputs.diff != 0 || ${{ github.event_name == 'workflow_dispatch' }}
         run: ./gradlew kotlinSourcesJar
 
       - name: Publish to Maven Central
-        if: steps.diff.outputs.diff != 0
+        if: steps.diff.outputs.diff != 0 || ${{ github.event_name == 'workflow_dispatch' }}
         run: ./gradlew --info publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}


### PR DESCRIPTION
Sometimes the publish workflow fails (like when Sonatype changes their credentials out from under us), and the automated workflow can't be re-run. And if it could, it wouldn't do anything if the version file wasn't changed. This makes it so we can run it whenever we want, regardless of if the version file changed (so, essentially, allowing us to force publish without mucking with the versions).

This won't overwrite anything in the publish step; if the version itself hasn't actually changed, maven will reject it.

This is solely to fix instances like where an autopublish failed for some reason and we need to re-try it