### PR TITLE
Fix completable token validation methods

### DIFF
--- a/stytch/src/main/kotlin/com/stytch/java/b2b/api/sessions/Sessions.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/b2b/api/sessions/Sessions.kt
@@ -436,7 +436,7 @@ public interface Sessions {
      * The value for leeway is the maximum allowable difference when comparing
      * timestamps. It defaults to zero.
      */
-    public suspend fun authenticateJwtLocalCompletable(
+    public fun authenticateJwtLocalCompletable(
         jwt: String,
         maxTokenAgeSeconds: Int?,
         authorizationCheck: AuthorizationCheck? = null,
@@ -715,7 +715,7 @@ internal class SessionsImpl(
         }
     }
 
-    override suspend fun authenticateJwtLocalCompletable(
+    override fun authenticateJwtLocalCompletable(
         jwt: String,
         maxTokenAgeSeconds: Int?,
         authorizationCheck: AuthorizationCheck?,

--- a/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/common/Version.kt
@@ -1,3 +1,3 @@
 package com.stytch.java.common
 
-internal const val VERSION = "6.0.0"
+internal const val VERSION = "6.1.0"

--- a/stytch/src/main/kotlin/com/stytch/java/consumer/api/m2m/M2M.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/consumer/api/m2m/M2M.kt
@@ -148,7 +148,7 @@ public interface M2M {
      * Stytch client library. You may pass in an optional set of scopes that the JWT must contain in
      * order to enforce permissions.
      */
-    public suspend fun authenticateTokenCompletable(
+    public fun authenticateTokenCompletable(
         data: AuthenticateTokenRequest,
     ): CompletableFuture<StytchResult<AuthenticateTokenResponse>>
     // ENDMANUAL(AuthenticateM2MToken)
@@ -241,7 +241,7 @@ internal class M2MImpl(
         coroutineScope.launch { callback(authenticateToken(data)) }
     }
 
-    override suspend fun authenticateTokenCompletable(
+    override fun authenticateTokenCompletable(
         data: AuthenticateTokenRequest,
     ): CompletableFuture<StytchResult<AuthenticateTokenResponse>> {
         return coroutineScope.async { authenticateToken(data) }.asCompletableFuture()

--- a/stytch/src/main/kotlin/com/stytch/java/consumer/api/m2m/M2M.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/consumer/api/m2m/M2M.kt
@@ -148,9 +148,7 @@ public interface M2M {
      * Stytch client library. You may pass in an optional set of scopes that the JWT must contain in
      * order to enforce permissions.
      */
-    public fun authenticateTokenCompletable(
-        data: AuthenticateTokenRequest,
-    ): CompletableFuture<StytchResult<AuthenticateTokenResponse>>
+    public fun authenticateTokenCompletable(data: AuthenticateTokenRequest): CompletableFuture<StytchResult<AuthenticateTokenResponse>>
     // ENDMANUAL(AuthenticateM2MToken)
 }
 
@@ -241,9 +239,7 @@ internal class M2MImpl(
         coroutineScope.launch { callback(authenticateToken(data)) }
     }
 
-    override fun authenticateTokenCompletable(
-        data: AuthenticateTokenRequest,
-    ): CompletableFuture<StytchResult<AuthenticateTokenResponse>> {
+    override fun authenticateTokenCompletable(data: AuthenticateTokenRequest): CompletableFuture<StytchResult<AuthenticateTokenResponse>> {
         return coroutineScope.async { authenticateToken(data) }.asCompletableFuture()
     }
 

--- a/stytch/src/main/kotlin/com/stytch/java/consumer/api/sessions/Sessions.kt
+++ b/stytch/src/main/kotlin/com/stytch/java/consumer/api/sessions/Sessions.kt
@@ -319,7 +319,7 @@ public interface Sessions {
      * The value for leeway is the maximum allowable difference when comparing
      * timestamps. It defaults to zero.
      */
-    public suspend fun authenticateJwtLocalCompletable(
+    public fun authenticateJwtLocalCompletable(
         jwt: String,
         maxTokenAgeSeconds: Int?,
         leeway: Int = 0,
@@ -541,7 +541,7 @@ internal class SessionsImpl(
         }
     }
 
-    override suspend fun authenticateJwtLocalCompletable(
+    override fun authenticateJwtLocalCompletable(
         jwt: String,
         maxTokenAgeSeconds: Int?,
         leeway: Int,

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,1 +1,1 @@
-version = "6.0.0"
+version = "6.1.0"


### PR DESCRIPTION
These manual methods were mistakenly made suspending functions when they should not be.