### PR TITLE
Dependabot Updates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,8 @@ allprojects {
             // Dependabot forces
             force("com.fasterxml.woodstox:woodstox-core:6.4.0")
             force("com.google.guava:guava:32.0.1-jre")
-            force("com.fasterxml.jackson.core:jackson-core:2.13.0")
+            force("com.fasterxml.jackson.core:jackson-core:2.13.4")
+            force("com.fasterxml.jackson.core:jackson-databind:2.13.4.2")
             force("ch.qos.logback:logback-core:1.3.15")
         }
     }


### PR DESCRIPTION
Confirmed in Maven that _these_ versions have no open CVEs